### PR TITLE
fix(ci): put the repo root on sys.path so `pytest` can import `backend`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,12 @@ minversion = 7.0
 # with `pytest tests/`.
 testpaths = backend/tests
 
+# Put the repository root on sys.path so `import backend` resolves regardless
+# of how pytest is invoked. `python -m pytest` adds the current directory
+# implicitly; the `pytest` console script does not — which is how the suite
+# passed locally and failed in CI with "No module named 'backend'".
+pythonpath = .
+
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary

`main` is currently red. The **Backend tests** job fails with 5 collection errors:

```
ImportError while importing test module '.../backend/tests/test_config.py'
E   ModuleNotFoundError: No module named 'backend'
```

This is a one-line follow-up to #37, which merged before its CI run finished. Every other job in that run passed (smoke test, frontend, lint & types, security scan); this was the only failure, and the Docker job was skipped because it is gated on tests.

## Root cause

`python -m pytest` prepends the current directory to `sys.path`. The `pytest` console script does **not**. Because `backend/tests/` has no `__init__.py`, pytest inserts *that* directory into `sys.path` rather than the repository root, so `import backend` fails.

The suite was verified locally with `python -m pytest` and passed; CI invokes `pytest` and could not import the package under test. The failure looked selective — 5 of 9 files — because those 5 import `backend.*` at module level, while the other 4 only touch it inside fixtures, so they collected fine.

## Fix

```ini
# pytest.ini
pythonpath = .
```

Makes path resolution explicit and invocation-independent, rather than an accident of how pytest happens to be launched. Supported natively since pytest 7.0 (the repo pins 7.4.3).

## Testing

Verified against this branch, rebased onto current `main`:

| Command | Result |
|---|---|
| `pytest` (console script — what CI runs) | 181 passed, 72.87% coverage |
| `python -m pytest` | 181 passed, 72.87% coverage |
| `ruff check backend/` | clean |
| `ruff format --check backend/` | clean |
| `mypy backend/core backend/api backend/repositories` | clean |
| `bandit -r backend/ -ll` | no issues |

Before the fix, `pytest` reproduced CI's failure exactly (same 5 modules).

## Why this cannot silently regress

CI runs the `pytest` console script, which is the invocation that fails without this setting. Any future change that breaks path resolution fails the build rather than passing locally and breaking in CI.

## Risk

Minimal. One file, six lines, no runtime code touched — `pytest.ini` is not read by the application.

## Rollback

`git revert` this commit. The only consequence is that backend tests stop collecting again.

## Note on process

This is a separate PR because #37 is already merged and a merged PR cannot carry follow-up work. Enabling required status checks on `main` would prevent the underlying situation — the smoke job added in #37 caught a real defect on its first run, but only if the run is allowed to finish before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0131M3g3R8vk8vpi6WL7Lgo1)_