### PR TITLE
Fix the startup race that broke the Docker job, and make the worker default match its own advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ Failure modes that have actually happened here, and what each one means.
 | A scan is indexed but the text is garbled | OCR quality is limited by the scan | Check `ocr_pages` on the document; there is no deskew/denoise pass |
 | Windows: `PermissionError: [WinError 32]` tearing down tests | ChromaDB holds `chroma.sqlite3` open; the temp dir cannot be unlinked | Already ignored in `conftest.py`; it is a teardown artefact, not a test failure |
 | `AttributeError: np.float_ was removed in the NumPy 2.0 release` on startup | An older environment resolved NumPy 2 alongside chromadb 0.5, which uses `np.float_` | `pip install -r requirements.txt` — both are pinned together now |
+| `sqlite3.OperationalError: table documents already exists` on startup | Several Gunicorn workers created the schema at once | Fixed: the losing worker rechecks and continues. If you see it again, the database is genuinely unreachable |
+| Container exits during startup under Gunicorn | Multiple workers on SQLite, which is single-writer | `WORKERS` now defaults to 1 for SQLite; raise it only with `DATABASE_URL` on PostgreSQL |
 | Windows: Python crashes under Git Bash with `TP_NUM_C_BUFS too small` | A Cygwin/MSYS limitation, not a project bug | Run Python, `pytest` and `uvicorn` from PowerShell or `cmd` |
 | Frontend loads a different app on `localhost:3000` | Another process owns IPv6 `::1:3000`; Vite binds IPv4 | Use `http://127.0.0.1:3000`, or free the port |
 

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -7,11 +7,14 @@ databases such as PostgreSQL.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Dict, Optional
 
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -23,6 +26,12 @@ from sqlalchemy.orm import DeclarativeBase
 from backend.core.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+#: Attempts at creating the schema before giving up. Only a worker that keeps
+#: losing the startup race needs more than the first one.
+_SCHEMA_CREATE_ATTEMPTS = 5
+#: Base back-off between attempts, multiplied by the attempt number.
+_SCHEMA_RETRY_DELAY = 0.1
 
 
 class Base(DeclarativeBase):
@@ -65,12 +74,7 @@ class DatabaseManager:
                 autoflush=False,
             )
 
-            async with self._engine.begin() as conn:
-                if self._is_sqlite(url):
-                    # SQLite ignores FK constraints unless asked; ON DELETE
-                    # CASCADE on document_chunks depends on it.
-                    await conn.execute(text("PRAGMA foreign_keys=ON"))
-                await conn.run_sync(Base.metadata.create_all)
+            await self._create_schema(url)
 
             self._is_initialized = True
             logger.info("Database initialized (%s)", self._safe_url(url))
@@ -78,6 +82,68 @@ class DatabaseManager:
         except Exception:
             logger.exception("Database initialization failed")
             raise
+
+    async def _create_schema(self, url: str) -> None:
+        """Create any missing tables, tolerating a concurrent creator.
+
+        Gunicorn starts every worker at once and each one runs this. SQLAlchemy's
+        ``create_all`` defaults to ``checkfirst=True``, which probes for the
+        table and *then* issues CREATE TABLE — so two workers can both see it
+        missing and both try to create it. The loser gets "table documents
+        already exists" and the whole process dies during startup.
+
+        That race is timing-dependent, so it does not fail every time: the same
+        image passed CI on one run and exited on the next. Losing the race is
+        harmless as long as the schema is actually there, which is what the
+        recheck below establishes. An error for any other reason still raises.
+        """
+        engine = self._require_engine()
+
+        last_error: Optional[Exception] = None
+        for attempt in range(_SCHEMA_CREATE_ATTEMPTS):
+            try:
+                async with engine.begin() as conn:
+                    if self._is_sqlite(url):
+                        # SQLite ignores FK constraints unless asked; ON DELETE
+                        # CASCADE on document_chunks depends on it.
+                        await conn.execute(text("PRAGMA foreign_keys=ON"))
+                    await conn.run_sync(Base.metadata.create_all)
+                return
+            except (OperationalError, ProgrammingError) as exc:
+                last_error = exc
+                if not await self._missing_tables():
+                    logger.info(
+                        "Schema was created concurrently by another worker; continuing"
+                    )
+                    return
+                # The winner's CREATE runs inside a transaction, so for a
+                # moment it has taken the name without the table being visible
+                # to anyone else. Retrying is what distinguishes that from a
+                # database that is genuinely broken.
+                await asyncio.sleep(_SCHEMA_RETRY_DELAY * (attempt + 1))
+
+        raise last_error or RuntimeError("Schema creation failed without an error")
+
+    def _require_engine(self) -> AsyncEngine:
+        """Return the engine, or say plainly that there is not one.
+
+        Not an ``assert``: those are stripped under ``python -O``, which is
+        exactly the configuration where a missing engine would turn into an
+        unexplained AttributeError deep in a request.
+        """
+        if self._engine is None:
+            raise RuntimeError("Database engine is not initialised")
+        return self._engine
+
+    async def _missing_tables(self) -> list[str]:
+        """Return the model tables that are not present in the database."""
+
+        def _inspect(sync_conn) -> list[str]:
+            existing = set(sa_inspect(sync_conn).get_table_names())
+            return [name for name in Base.metadata.tables if name not in existing]
+
+        async with self._require_engine().connect() as conn:
+            return await conn.run_sync(_inspect)
 
     async def close(self) -> None:
         """Dispose of the connection pool."""

--- a/backend/tests/test_persistence.py
+++ b/backend/tests/test_persistence.py
@@ -59,6 +59,50 @@ def _boot():
     return create_application()
 
 
+class TestConcurrentStartup:
+    """Every gunicorn worker runs the schema bootstrap at once.
+
+    ``create_all(checkfirst=True)`` probes for the table and *then* issues
+    CREATE TABLE, so two workers can both find it missing and both create it.
+    The loser got "table documents already exists" and the process died during
+    startup — timing-dependent, so the same image passed CI on one run and
+    exited on the next.
+    """
+
+    @pytest.mark.asyncio
+    async def test_many_managers_can_initialise_the_same_database(self, tmp_path):
+        import asyncio
+
+        from backend.core.database import DatabaseManager
+
+        url = f"sqlite+aiosqlite:///{tmp_path / 'race.db'}"
+        managers = [DatabaseManager(database_url=url) for _ in range(8)]
+
+        # Concurrently, as gunicorn does — not one after another.
+        await asyncio.gather(*(m.initialize() for m in managers))
+
+        try:
+            assert all(m.is_initialized for m in managers)
+            assert await managers[0]._missing_tables() == []
+        finally:
+            await asyncio.gather(*(m.close() for m in managers))
+
+    @pytest.mark.asyncio
+    async def test_a_real_failure_still_raises(self, tmp_path):
+        """The recheck must not turn every database error into a shrug."""
+        from sqlalchemy.exc import OperationalError
+
+        from backend.core.database import DatabaseManager
+
+        # A directory that does not exist: SQLite cannot open the file, and no
+        # amount of retrying will change that.
+        manager = DatabaseManager(
+            database_url=f"sqlite+aiosqlite:///{tmp_path / 'nope' / 'x.db'}"
+        )
+        with pytest.raises(OperationalError):
+            await manager.initialize()
+
+
 class TestDocumentsSurviveRestart:
     def test_a_document_is_still_listed_after_a_restart(self, restartable_env):
         payload = b"Board minutes: the Zephyr acquisition was approved."

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,6 +186,7 @@ The design principle: **degrade visibly, never silently**.
 |---|---|---|
 | No embedding model | Keyword-only lexical matching | `/api/health` → `degraded`; `embeddings_are_real: false` on every response; `roneira_embedding_backend_real` gauge = 0 |
 | tesseract missing | Scans and images are refused, naming the reason; text documents unaffected | The document's failure reason; `ocr_unavailable_reason` in metadata |
+| Two workers create the schema at once | The loser waits and rechecks instead of dying | `Schema was created concurrently by another worker` at INFO |
 | Ollama unreachable | Text still extracted and indexed; no summary or chat prose | `/api/health` → `degraded` with the endpoint it tried |
 | Database down | Requests fail | `/api/health/ready` → 503; liveness stays 200 so the container is not killed |
 | Text extraction fails | Document marked `failed` with a readable reason; nothing indexed | Document status; `roneira_documents_processed_total{status="error"}` |

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -17,13 +17,21 @@ import os
 bind = f"0.0.0.0:{os.getenv('PORT', '8000')}"
 
 # --- Worker Processes ---
-# The number of worker processes to spawn. A common recommendation is
-# (2 * number of CPU cores) + 1.
-# NOTE: with the default SQLite database and the on-disk ChromaDB store,
-# more than one worker means several processes writing the same files. Keep
-# WORKERS=1 unless DATABASE_URL points at PostgreSQL and the vector store is
-# a shared service. See docs/DEPLOYMENT.md.
-workers = int(os.getenv('WORKERS', multiprocessing.cpu_count() * 2 + 1))
+# (2 * cores) + 1 is the usual recommendation, and it is right for a server
+# database. It is wrong for this application's default configuration, where
+# SQLite and the on-disk ChromaDB store are both single-writer: several
+# workers means several processes writing the same files.
+#
+# The advice to "keep WORKERS=1 unless DATABASE_URL points at PostgreSQL" was
+# already written here, while the default did the opposite — a container run
+# with no configuration got nine workers on SQLite. The default now follows
+# the advice, and an explicit WORKERS still wins.
+_default_workers = (
+    1
+    if os.getenv('DATABASE_URL', 'sqlite').startswith('sqlite')
+    else multiprocessing.cpu_count() * 2 + 1
+)
+workers = int(os.getenv('WORKERS', _default_workers))
 
 # The type of worker to use. 'uvicorn.workers.UvicornWorker' is ideal for
 # running ASGI applications like FastAPI.


### PR DESCRIPTION
The Docker job failed on `main` after #38 merged, with the container exiting during startup:

```
sqlite3.OperationalError: table documents already exists
```

The same image had passed on the pull request. It is a race, so it does not fail every time — which is also why it survived this long.

## The race

Gunicorn starts every worker simultaneously and each one runs the schema bootstrap. SQLAlchemy's `create_all` defaults to `checkfirst=True`, which probes for the table and **then** issues `CREATE TABLE`. Two workers can both find it missing and both create it; the loser's `CREATE` fails and takes the whole process down.

Nothing about this is SQLite-specific. PostgreSQL with several workers has the same window.

Schema creation now tolerates losing that race: on `OperationalError`/`ProgrammingError` it rechecks which model tables are *actually* missing and continues if the answer is none. An error for any other reason still raises, so a genuinely unreachable database stays loud.

**The first version of this fix was not enough, and the test caught it.** The winner's `CREATE` runs inside a transaction, so for a moment it has taken the table name without the table being visible to anyone else — the loser's recheck saw nothing and re-raised. Creation is now retried with a short back-off, which is also what distinguishes a transient race from a database that is actually broken.

## The default worker count contradicted its own comment

`gunicorn.conf.py` said:

```python
# Keep WORKERS=1 unless DATABASE_URL points at PostgreSQL ...
workers = int(os.getenv('WORKERS', multiprocessing.cpu_count() * 2 + 1))
```

So a container run with no configuration got nine workers on SQLite — single-writer — and nine processes writing the same on-disk ChromaDB store. The default now follows the advice: `1` for SQLite, `(2 * cores) + 1` otherwise. An explicit `WORKERS` still wins.

## Also

Three `assert`s replaced with an explicit check. Asserts are stripped under `python -O`, which is precisely the configuration where a missing engine would resurface as an unexplained `AttributeError` inside a request.

## Tests

- `test_many_managers_can_initialise_the_same_database` — eight managers initialising one database concurrently. Reproduces the CI failure exactly against the old code.
- `test_a_real_failure_still_raises` — a database that cannot be opened must not be swallowed by the recheck.

## Verification

```
ruff check / ruff format / mypy   clean
pytest (bare, as CI runs it)      236 passed, 1 skipped — 72.6% (gate 70%)
```