### PR TITLE
Rerank retrieved passages, and give the interface a point of view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,15 @@ RETRIEVAL_MIN_SCORE=0.15
 # semantic similarity only.
 HYBRID_RETRIEVAL=true
 
+# Re-score the shortlist with a cross-encoder, which reads the question and
+# the passage together rather than comparing two vectors computed separately.
+# Measured over docs/samples/ this takes recall@1 from 69% to 77% and recall@3
+# from 92% to 100% — see scripts/eval_retrieval.py. Costs an ~80MB model
+# download on first use and roughly 100ms per query on CPU. If the model
+# cannot be loaded, search continues on embedding similarity and says so.
+RERANK_RESULTS=true
+RERANK_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+
 # When true, startup fails unless a real embedding model loads. When false,
 # the service falls back to keyword-only matching: it works, but paraphrased
 # questions will not find the right passage. Turn this on wherever answer

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ pip install sentence-transformers
 The first run downloads ~90MB. To make the service refuse to start rather than
 silently fall back, set `REQUIRE_REAL_EMBEDDINGS=true`.
 
+The same package supplies the cross-encoder used to rerank results, which is
+the single largest accuracy gain available here — recall@1 goes from 69% to
+77% and recall@3 from 92% to 100% on the bundled corpus. To see that on your
+own machine:
+
+```bash
+python scripts/eval_retrieval.py --compare
+```
+
 ### Reading scanned documents
 
 Scanned PDFs and image uploads (`.png`, `.jpg`, `.tiff`) are read with OCR.
@@ -262,6 +271,7 @@ ones that change behaviour most:
 | `CHUNK_SIZE` / `CHUNK_OVERLAP` | `1000` / `200` | Retrieval granularity |
 | `RETRIEVAL_MIN_SCORE` | `0.15` | Raise to cut weak citations, lower to widen recall |
 | `HYBRID_RETRIEVAL` | `true` | `false` ranks by meaning alone, ignoring keyword overlap |
+| `RERANK_RESULTS` | `true` | Cross-encoder reranking. Measured: recall@1 69% → 77%. Costs an ~80MB download and ~100ms/query |
 | `ENABLE_OCR` / `TESSERACT_PATH` | `true` / auto | Read scanned pages; point at the binary if it is not on `PATH` |
 | `DATABASE_URL` | SQLite | PostgreSQL is required for more than one worker |
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -111,6 +111,14 @@ class Settings(BaseSettings):
     #: the one containing the literal term the question asked for.
     hybrid_retrieval: bool = Field(default=True)
 
+    #: Re-score the retrieved candidates with a cross-encoder, which reads the
+    #: question and the passage together instead of comparing two vectors that
+    #: were computed independently. Materially more accurate at ranking the
+    #: right passage first; costs a ~80MB model download and roughly 100ms per
+    #: query on CPU. Off leaves retrieval on embedding similarity.
+    rerank_results: bool = Field(default=True)
+    rerank_model: str = Field(default="cross-encoder/ms-marco-MiniLM-L-6-v2")
+
     #: Refuse to start unless a real embedding model loads. Otherwise the
     #: service falls back to keyword-only lexical matching, which works but
     #: cannot match paraphrases — set this true where that is unacceptable.

--- a/backend/services/reranking.py
+++ b/backend/services/reranking.py
@@ -1,0 +1,118 @@
+"""Cross-encoder reranking of retrieved passages.
+
+Vector search compares a query embedding to passage embeddings that were
+computed without ever seeing the query. That is what makes it fast enough to
+search a whole corpus, and it is also its ceiling: the passage vector cannot
+emphasise the part a particular question is about.
+
+A cross-encoder reads the query and the passage *together* and scores the pair.
+It is far too slow to run over a corpus, and exactly right for reordering the
+handful of candidates retrieval already narrowed things down to.
+
+The model is ``cross-encoder/ms-marco-MiniLM-L-6-v2`` (~80MB), trained on MS
+MARCO passage ranking. It arrives with sentence-transformers, which is already
+an optional dependency here, so this adds a download rather than a package.
+
+Like every other optional capability in this codebase, absence is reported
+rather than hidden: no sentence-transformers, no download, or a load failure
+all leave retrieval working on its existing ranking and say why.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+try:
+    from sentence_transformers import CrossEncoder
+
+    CROSS_ENCODER_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency
+    CrossEncoder = None  # type: ignore[assignment]
+    CROSS_ENCODER_AVAILABLE = False
+
+DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+#: Passage characters handed to the cross-encoder. The model truncates at 512
+#: tokens anyway; cutting here keeps the batch small and predictable.
+MAX_PASSAGE_CHARS = 2000
+
+
+class Reranker:
+    """Reorders candidate passages by cross-encoder relevance."""
+
+    def __init__(self, model_name: str = DEFAULT_MODEL, enabled: bool = True):
+        self.model_name = model_name
+        self._enabled = enabled
+        self._model = None
+        self._reason: Optional[str] = None if enabled else "reranking is disabled"
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Load the model, degrading to a no-op if it cannot be had."""
+        if self._initialized:
+            return
+        self._initialized = True
+
+        if not self._enabled:
+            return
+
+        if not CROSS_ENCODER_AVAILABLE:
+            self._degrade(
+                "sentence-transformers is not installed, so passages are ranked "
+                "by embedding similarity alone"
+            )
+            return
+
+        try:
+            # Loading pulls the model on first use and is CPU-bound; keep it
+            # off the event loop, as the embedding service does.
+            loop = asyncio.get_running_loop()
+            self._model = await loop.run_in_executor(
+                None, lambda: CrossEncoder(self.model_name)
+            )
+            self._reason = None
+            logger.info("Reranker initialized with '%s'", self.model_name)
+        except Exception as exc:
+            self._degrade(f"could not load '{self.model_name}': {exc}")
+
+    def _degrade(self, reason: str) -> None:
+        self._model = None
+        self._reason = reason
+        logger.warning("Reranking unavailable: %s", reason)
+
+    @property
+    def is_available(self) -> bool:
+        return self._model is not None
+
+    @property
+    def degraded_reason(self) -> Optional[str]:
+        return self._reason
+
+    async def rank(self, query: str, passages: Sequence[str]) -> Optional[List[int]]:
+        """Return candidate indices ordered best-first, or None if unavailable.
+
+        Returning indices rather than reordered passages keeps this decoupled
+        from whatever the caller is actually holding, and means the caller
+        controls what happens to the scores it already has.
+        """
+        if not self.is_available or len(passages) < 2:
+            return None
+
+        pairs: List[Tuple[str, str]] = [
+            (query, passage[:MAX_PASSAGE_CHARS]) for passage in passages
+        ]
+
+        try:
+            loop = asyncio.get_running_loop()
+            scores = await loop.run_in_executor(None, lambda: self._model.predict(pairs))
+        except Exception as exc:
+            # A reranking failure must not fail the search. The existing order
+            # is a worse answer, not no answer.
+            logger.warning("Reranking failed, keeping the original order: %s", exc)
+            return None
+
+        return sorted(range(len(passages)), key=lambda i: float(scores[i]), reverse=True)

--- a/backend/services/retrieval_service.py
+++ b/backend/services/retrieval_service.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from backend.core.config import get_settings
 from backend.services.embedding_service import EmbeddingService
+from backend.services.reranking import Reranker
 from backend.services.text_splitter_service import TextSplitterService
 from backend.services.vector_store_service import (
     SearchResult,
@@ -95,6 +96,9 @@ class RetrievalService:
         )
         self.min_score = settings.retrieval_min_score
         self.hybrid_enabled = settings.hybrid_retrieval
+        self.reranker = Reranker(
+            model_name=settings.rerank_model, enabled=settings.rerank_results
+        )
 
         self.text_splitter = TextSplitterService(
             default_chunk_size=self.chunk_size,
@@ -133,6 +137,7 @@ class RetrievalService:
             return
         await self.embedding_service.initialize()
         await self.vector_store.initialize()
+        await self.reranker.initialize()
         self.is_initialized = True
 
         if not self.embedding_service.is_real:
@@ -336,6 +341,16 @@ class RetrievalService:
 
         if self.hybrid_enabled:
             candidates = _rank_hybrid(query, candidates)
+
+        # The cross-encoder reads the question and the passage together, so it
+        # runs last and gets the final say. Hybrid ranking still decides which
+        # candidates are worth that cost. Scores are untouched either way:
+        # cross-encoder outputs are unbounded logits, not similarities, and
+        # writing them into `score` would break RETRIEVAL_MIN_SCORE and the
+        # "% match" a citation shows.
+        order = await self.reranker.rank(query, [c.content for c in candidates])
+        if order is not None:
+            candidates = [candidates[i] for i in order]
 
         filtered_results = candidates[:top_k]
 

--- a/backend/tests/test_reranking.py
+++ b/backend/tests/test_reranking.py
@@ -1,0 +1,113 @@
+"""Cross-encoder reranking.
+
+Measured over `docs/samples/` with scripts/eval_retrieval.py, reranking moves
+recall@1 from 69% to 77% and recall@3 from 92% to 100%. These tests cover the
+behaviour that has to hold regardless of the model: it must never lose results,
+never rewrite the scores a citation reports, and never turn its own failure
+into a failed search.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.reranking import Reranker
+
+#: The model is an ~80MB download. Where it is absent these skip rather than
+#: fail, exactly as the OCR tests do.
+_probe = Reranker()
+
+
+async def _available() -> bool:
+    await _probe.initialize()
+    return _probe.is_available
+
+
+class TestAvailabilityIsHonest:
+    @pytest.mark.asyncio
+    async def test_a_disabled_reranker_says_so_and_does_nothing(self):
+        reranker = Reranker(enabled=False)
+        await reranker.initialize()
+
+        assert reranker.is_available is False
+        assert reranker.degraded_reason
+        assert await reranker.rank("anything", ["a", "b"]) is None
+
+    @pytest.mark.asyncio
+    async def test_an_unloadable_model_degrades_instead_of_raising(self):
+        """A missing model must not take the search down with it."""
+        reranker = Reranker(model_name="not-a-real-model/does-not-exist")
+        await reranker.initialize()
+
+        assert reranker.is_available is False
+        assert reranker.degraded_reason
+        assert await reranker.rank("q", ["a", "b"]) is None
+
+    @pytest.mark.asyncio
+    async def test_a_single_candidate_needs_no_reranking(self):
+        reranker = Reranker()
+        await reranker.initialize()
+
+        assert await reranker.rank("q", ["only one"]) is None
+
+
+class TestRanking:
+    @pytest.mark.asyncio
+    async def test_it_ranks_the_passage_that_answers_the_question_first(self):
+        if not await _available():
+            pytest.skip(f"cross-encoder unavailable: {_probe.degraded_reason}")
+
+        passages = [
+            "The office cafeteria serves lunch between noon and two.",
+            "Employees in their first year receive 15 days of paid time off.",
+            "The car park is accessible with a staff badge.",
+        ]
+
+        order = await _probe.rank("how much annual leave do new joiners get", passages)
+
+        assert order is not None
+        assert order[0] == 1, "the PTO passage answers the question"
+
+    @pytest.mark.asyncio
+    async def test_every_candidate_survives_reranking(self):
+        """Reordering must not silently drop a result."""
+        if not await _available():
+            pytest.skip(f"cross-encoder unavailable: {_probe.degraded_reason}")
+
+        passages = [f"passage number {i} about invoices" for i in range(6)]
+
+        order = await _probe.rank("invoice total", passages)
+
+        assert order is not None
+        assert sorted(order) == list(range(len(passages)))
+
+
+class TestRetrievalIntegration:
+    @pytest.mark.asyncio
+    async def test_scores_still_mean_what_they_meant(self):
+        """Cross-encoder outputs are unbounded logits, not similarities.
+
+        Writing them into `score` would silently break RETRIEVAL_MIN_SCORE and
+        the "% match" shown next to a citation, so reranking may reorder
+        results but must leave their scores alone.
+        """
+        from backend.services.vector_store_service import SearchResult
+
+        before = [
+            SearchResult(
+                chunk_id=f"c{i}",
+                document_id="d",
+                content=f"passage {i}",
+                score=0.9 - i / 10,
+                metadata={},
+            )
+            for i in range(4)
+        ]
+        original = {r.chunk_id: r.score for r in before}
+
+        reranker = Reranker()
+        await reranker.initialize()
+        order = await reranker.rank("anything at all", [r.content for r in before])
+
+        after = [before[i] for i in order] if order else before
+        assert {r.chunk_id: r.score for r in after} == original

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,9 +104,40 @@ improves precision but not recall: a chunk the vector search never returned
 cannot be recovered by re-ranking. A real BM25/FTS index over
 `document_chunks`, unioned with the vector hits, is the upgrade path.
 
-`SearchResult.score` keeps the vector similarity even after re-ranking, so
+Finally, a **cross-encoder** reads the question and each surviving passage
+*together* and scores the pair. A bi-encoder cannot do this: the passage vector
+is computed before any question exists, so it cannot emphasise the part a
+particular question is about. Cross-encoders are far too slow to run over a
+corpus and exactly right for reordering a shortlist.
+
+`SearchResult.score` keeps the vector similarity through all of this, so
 `RETRIEVAL_MIN_SCORE` keeps its meaning and a citation still reports a
-comparable number. Set `HYBRID_RETRIEVAL=false` to rank on similarity alone.
+comparable number. Cross-encoder outputs are unbounded logits, not
+similarities; writing them into `score` would quietly break both.
+
+### Measured
+
+`scripts/eval_retrieval.py` asks 13 paraphrased questions whose correct source
+document is known, against the whole 22-document sample corpus. The questions
+avoid the documents' own wording — "how much do we owe Quantum Industrial
+Systems" has to reach "TOTAL DUE" — because matching a shared noun is not
+evidence that retrieval works.
+
+| Ranking | recall@1 | recall@3 | MRR |
+|---|---|---|---|
+| Semantic only | 62% | 77% | 0.699 |
+| + keyword (hybrid) | 69% | 92% | 0.827 |
+| + cross-encoder | 77% | 100% | 0.859 |
+| Both | 77% | 100% | 0.859 |
+
+Two things worth reading off that table. The cross-encoder runs last and
+reorders everything, so **hybrid adds nothing on top of it** — the last two
+rows are identical. Hybrid earns its place as the fallback: without
+sentence-transformers there is no cross-encoder, and hybrid is then the
+difference between 69% and 62%.
+
+Set `RERANK_RESULTS=false` to skip the cross-encoder, or `HYBRID_RETRIEVAL=false`
+to rank on similarity alone.
 
 PDF extraction emits `--- Page N ---` markers, and
 `retrieval_service._page_for_offset` maps a chunk's character offset back to

--- a/scripts/demo_task1_catalog.py
+++ b/scripts/demo_task1_catalog.py
@@ -979,9 +979,7 @@ def main():
     print(f"   Created: {catalog_path}")
 
     print("\nGenerating Quality Report...")
-    quality_path = generate_quality_report(
-        str(output_dir / "task1_quality_report.html")
-    )
+    quality_path = generate_quality_report(str(output_dir / "task1_quality_report.html"))
     print(f"   Created: {quality_path}")
 
     print("\nGenerating Lineage Graph...")

--- a/scripts/demo_task3_ontology.py
+++ b/scripts/demo_task3_ontology.py
@@ -67,15 +67,9 @@ def create_enhanced_ontology():
     ontology.add_relation(vec_db.node_id, embeddings.node_id, RelationType.CONTAINS)
 
     # Add document processing concepts
-    ocr = ontology.add_concept(
-        "OCR", "Optical Character Recognition for text extraction"
-    )
-    chunking = ontology.add_concept(
-        "Chunking", "Breaking documents into smaller pieces"
-    )
-    parsing = ontology.add_concept(
-        "Parsing", "Extracting structured data from documents"
-    )
+    ocr = ontology.add_concept("OCR", "Optical Character Recognition for text extraction")
+    chunking = ontology.add_concept("Chunking", "Breaking documents into smaller pieces")
+    parsing = ontology.add_concept("Parsing", "Extracting structured data from documents")
 
     ontology.add_relation(
         ocr.node_id,

--- a/scripts/demo_task4_orchestration.py
+++ b/scripts/demo_task4_orchestration.py
@@ -298,9 +298,7 @@ def generate_performance_dashboard_html(output_path: Path):
     ]
 
     total_calls = sum(p["calls"] for p in performance_data)
-    avg_success = sum(p["success_rate"] for p in performance_data) / len(
-        performance_data
-    )
+    avg_success = sum(p["success_rate"] for p in performance_data) / len(performance_data)
 
     # Build performance table rows
     table_rows = ""

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -1,0 +1,211 @@
+"""Measure retrieval accuracy against the bundled sample corpus.
+
+Retrieval changes are easy to argue about and hard to settle without numbers.
+This indexes `docs/samples/` into a throwaway store, asks a fixed set of
+questions whose correct source document is known, and reports how often the
+right document comes back and how high it ranks.
+
+    python scripts/eval_retrieval.py                  # current settings
+    python scripts/eval_retrieval.py --no-hybrid      # semantic ranking only
+    python scripts/eval_retrieval.py --no-rerank      # skip the cross-encoder
+    python scripts/eval_retrieval.py --compare        # every combination
+
+The questions are deliberately *paraphrased* rather than quoting the document.
+"How much do we owe Quantum Industrial Systems" has to reach "TOTAL DUE";
+"vacation days for new starters" has to reach "New Employees (Year 1)". A
+keyword index scores badly on these, which is the point — it is what tells you
+whether semantic retrieval is actually working rather than coincidentally
+matching a shared noun.
+
+Metrics
+    recall@k  the correct document appears somewhere in the top k
+    MRR       1/rank of the correct document, averaged. Rewards ranking it
+              first rather than merely including it, which is what matters
+              when only the top few chunks reach the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import tempfile
+from typing import List, NamedTuple
+
+# Run from a checkout without installing the package.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class Question(NamedTuple):
+    """A question and the sample document that answers it."""
+
+    text: str
+    expected: str
+
+
+#: Every expected answer was read out of the sample it points at. The wording
+#: avoids the document's own phrasing wherever possible.
+GOLDEN: List[Question] = [
+    # --- invoices: numeric and entity lookups ------------------------------
+    Question("how much do we owe Quantum Industrial Systems", "INV-2025-1001.pdf"),
+    Question("which supplier is based in New York", "INV-2025-1002.pdf"),
+    Question(
+        "who should I contact at Enterprise Solutions about their bill",
+        "INV-2025-1001.pdf",
+    ),
+    Question("what did we pay for cloud infrastructure setup", "INV-2025-1002.pdf"),
+    Question(
+        "which invoice covers a backup system and office supplies", "INV-2025-1003.pdf"
+    ),
+    Question("invoice from the shipping company in Houston", "INV-2025-1003.pdf"),
+    Question("INV-2025-1001", "INV-2025-1001.pdf"),
+    # --- HR policies: paraphrase-heavy -------------------------------------
+    Question("how many vacation days do new starters get", "hr_2024_001.pdf"),
+    Question("can I carry unused leave into next year", "hr_2024_001.pdf"),
+    Question("what is the allowance for working from home", "hr_2024_002.pdf"),
+    Question("how many days a week must I be in the office", "hr_2024_002.pdf"),
+    Question("policy for the manufacturing firm in Chicago", "hr_2024_002.pdf"),
+    Question(
+        "time off entitlement at the San Francisco technology company", "hr_2024_001.pdf"
+    ),
+]
+
+TOP_K = 5
+
+
+async def evaluate(hybrid: bool, rerank: bool) -> dict:
+    """Index the corpus and score the golden questions."""
+    workspace = tempfile.mkdtemp(prefix="roneira-eval-")
+    os.environ["VECTOR_STORE_PATH"] = os.path.join(workspace, "vectors")
+    os.environ["HYBRID_RETRIEVAL"] = "true" if hybrid else "false"
+    os.environ["RERANK_RESULTS"] = "true" if rerank else "false"
+
+    from backend.common.helpers import extract_text_from_file
+    from backend.core.config import reload_settings
+    from backend.services.retrieval_service import RetrievalService
+
+    reload_settings()
+    retrieval = RetrievalService()
+    await retrieval.initialize()
+
+    samples_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs", "samples"
+    )
+
+    # Index the *whole* corpus, not just the documents the questions point at.
+    # With only the five answer documents present, "is the right one in the top
+    # five" is true by construction and the score means nothing. The other
+    # seventeen are near-neighbours — more invoices, more HR policies — which
+    # is what makes ranking the correct one first a real result.
+    indexed = 0
+    for filename in sorted(os.listdir(samples_dir)):
+        if not filename.lower().endswith((".pdf", ".txt")):
+            continue
+        try:
+            text, _ = await extract_text_from_file(os.path.join(samples_dir, filename))
+        except Exception as exc:  # a sample we cannot read is not a test failure
+            print(f"  skipped {filename}: {exc}")
+            continue
+        await retrieval.index_document(
+            document_id=filename,
+            content=text,
+            metadata={"filename": filename},
+            owner_id="eval",
+        )
+        indexed += 1
+
+    hits_at = {1: 0, 3: 0, 5: 0}
+    reciprocal = 0.0
+    misses: List[str] = []
+
+    for question in GOLDEN:
+        result = await retrieval.retrieve(
+            query=question.text, top_k=TOP_K, min_score=0.0, owner_id="eval"
+        )
+        ranked = []
+        for item in result.results:
+            name = item.metadata.get("filename")
+            if name not in ranked:
+                ranked.append(name)
+
+        if question.expected in ranked:
+            rank = ranked.index(question.expected) + 1
+            reciprocal += 1 / rank
+            for k in hits_at:
+                if rank <= k:
+                    hits_at[k] += 1
+        else:
+            misses.append(question.text)
+
+    # Read before cleanup: the service resets on teardown, and reading after it
+    # reported keyword-only matching for a run that used a real model.
+    embeddings_are_real = retrieval.embeddings_are_real
+    await retrieval.cleanup()
+
+    total = len(GOLDEN)
+    return {
+        "embeddings_are_real": embeddings_are_real,
+        "documents_indexed": indexed,
+        "recall@1": hits_at[1] / total,
+        "recall@3": hits_at[3] / total,
+        "recall@5": hits_at[5] / total,
+        "mrr": reciprocal / total,
+        "misses": misses,
+    }
+
+
+def _print(label: str, scores: dict) -> None:
+    print(
+        f"{label:<28} "
+        f"recall@1 {scores['recall@1']:.0%}  "
+        f"recall@3 {scores['recall@3']:.0%}  "
+        f"recall@5 {scores['recall@5']:.0%}  "
+        f"MRR {scores['mrr']:.3f}"
+    )
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-hybrid", action="store_true")
+    parser.add_argument("--no-rerank", action="store_true")
+    parser.add_argument("--compare", action="store_true", help="score every combination")
+    args = parser.parse_args()
+
+    print(
+        f"{len(GOLDEN)} questions, answers spread over "
+        f"{len({q.expected for q in GOLDEN})} documents, scored against the whole "
+        f"sample corpus\n"
+    )
+
+    if args.compare:
+        results = {}
+        for hybrid, rerank, label in (
+            (False, False, "semantic only"),
+            (True, False, "+ keyword (hybrid)"),
+            (False, True, "+ cross-encoder"),
+            (True, True, "+ both"),
+        ):
+            results[label] = await evaluate(hybrid=hybrid, rerank=rerank)
+            _print(label, results[label])
+
+        if not next(iter(results.values()))["embeddings_are_real"]:
+            print(
+                "\nWARNING: no embedding model loaded, so these numbers describe "
+                "keyword matching. Install sentence-transformers."
+            )
+        return 0
+
+    scores = await evaluate(hybrid=not args.no_hybrid, rerank=not args.no_rerank)
+    _print("current settings", scores)
+    if scores["misses"]:
+        print("\nNot retrieved in the top 5:")
+        for miss in scores["misses"]:
+            print(f"  - {miss}")
+    if not scores["embeddings_are_real"]:
+        print("\nWARNING: keyword-only matching; install sentence-transformers.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/load_samples.py
+++ b/scripts/load_samples.py
@@ -128,9 +128,7 @@ def wait_for(
     """Poll until the document reaches a terminal state."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        body = client.get(
-            f"/api/documents/{document_id}/status", headers=headers
-        ).json()
+        body = client.get(f"/api/documents/{document_id}/status", headers=headers).json()
         if body["status"] in ("completed", "failed"):
             return body["status"]
         time.sleep(0.5)
@@ -184,7 +182,9 @@ def main() -> int:
                 ).json()
                 print(f"  {path.name}: {status} — {detail.get('error', '')}")
 
-        print(f"\n{completed} indexed, {failed} failed, {len(files) - len(queued)} rejected")
+        print(
+            f"\n{completed} indexed, {failed} failed, {len(files) - len(queued)} rejected"
+        )
 
         if completed:
             stats = client.get("/api/rag/stats", headers=headers).json()
@@ -198,7 +198,7 @@ def main() -> int:
                 )
 
             print("\nTry:")
-            print(f'  curl -X POST {args.url}/api/search \\')
+            print(f"  curl -X POST {args.url}/api/search \\")
             print(f'    -H "Authorization: Bearer {token[:16]}…" \\')
             print('    -H "Content-Type: application/json" \\')
             print("""    -d '{"query":"total amount due","top_k":3}'""")

--- a/scripts/verify-deployment.py
+++ b/scripts/verify-deployment.py
@@ -12,14 +12,16 @@ from pathlib import Path
 from typing import Dict, Any, List
 import time
 
+
 # Colors for output
 class Colors:
-    GREEN = '\033[92m'
-    RED = '\033[91m'
-    YELLOW = '\033[93m'
-    BLUE = '\033[94m'
-    BOLD = '\033[1m'
-    END = '\033[0m'
+    GREEN = "\033[92m"
+    RED = "\033[91m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    BOLD = "\033[1m"
+    END = "\033[0m"
+
 
 def print_status(message: str, status: str = "info"):
     """Print colored status messages"""
@@ -27,33 +29,37 @@ def print_status(message: str, status: str = "info"):
         "info": Colors.BLUE,
         "success": Colors.GREEN,
         "warning": Colors.YELLOW,
-        "error": Colors.RED
+        "error": Colors.RED,
     }.get(status, Colors.BLUE)
-    
+
     print(f"{color}[{status.upper()}]{Colors.END} {message}")
+
 
 class DeploymentVerifier:
     def __init__(self, base_url: str = "http://localhost:8000"):
-        self.base_url = base_url.rstrip('/')
+        self.base_url = base_url.rstrip("/")
         self.session = None
         self.test_results = []
-    
+
     async def __aenter__(self):
-        self.session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
-        )
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.session:
             await self.session.close()
-    
-    async def test_endpoint(self, endpoint: str, method: str = "GET", 
-                          data: Any = None, files: Any = None,
-                          expected_status: int = 200) -> Dict[str, Any]:
+
+    async def test_endpoint(
+        self,
+        endpoint: str,
+        method: str = "GET",
+        data: Any = None,
+        files: Any = None,
+        expected_status: int = 200,
+    ) -> Dict[str, Any]:
         """Test a single endpoint"""
         url = f"{self.base_url}{endpoint}"
-        
+
         try:
             if method == "GET":
                 async with self.session.get(url) as resp:
@@ -62,7 +68,7 @@ class DeploymentVerifier:
                         response_data = await resp.json()
                     except:
                         response_data = await resp.text()
-            
+
             elif method == "POST":
                 if files:
                     async with self.session.post(url, data=files) as resp:
@@ -72,32 +78,30 @@ class DeploymentVerifier:
                     async with self.session.post(url, json=data) as resp:
                         status = resp.status
                         response_data = await resp.json()
-            
+
             success = status == expected_status
             return {
                 "success": success,
                 "status_code": status,
                 "response": response_data,
-                "url": url
+                "url": url,
             }
-            
+
         except Exception as e:
-            return {
-                "success": False,
-                "error": str(e),
-                "url": url
-            }
-    
+            return {"success": False, "error": str(e), "url": url}
+
     async def test_health_check(self) -> bool:
         """Test health check endpoint"""
         print_status("Testing health check endpoint...", "info")
-        
+
         result = await self.test_endpoint("/health")
-        
+
         if result["success"]:
             health_data = result["response"]
-            print_status(f"Health check passed: {health_data.get('status', 'unknown')}", "success")
-            
+            print_status(
+                f"Health check passed: {health_data.get('status', 'unknown')}", "success"
+            )
+
             # Check individual services
             services = health_data.get("services", {})
             for service_name, service_status in services.items():
@@ -106,114 +110,132 @@ class DeploymentVerifier:
                     print_status(f"  ✓ {service_name}: {status_text}", "success")
                 else:
                     print_status(f"  ✗ {service_name}: {status_text}", "warning")
-            
+
             self.test_results.append(("Health Check", True, "All services checked"))
             return True
         else:
-            print_status(f"Health check failed: {result.get('error', 'Unknown error')}", "error")
-            self.test_results.append(("Health Check", False, result.get('error', 'Failed')))
+            print_status(
+                f"Health check failed: {result.get('error', 'Unknown error')}", "error"
+            )
+            self.test_results.append(
+                ("Health Check", False, result.get("error", "Failed"))
+            )
             return False
-    
+
     async def test_file_upload(self) -> str:
         """Test file upload with a sample file"""
         print_status("Testing file upload...", "info")
-        
+
         # Create a simple test file
         test_content = "This is a test document for Roneira AI.\nIt contains sample text for processing."
-        
+
         # Prepare multipart data
         data = aiohttp.FormData()
-        data.add_field('file', 
-                      test_content,
-                      filename='test_document.txt',
-                      content_type='text/plain')
-        
+        data.add_field(
+            "file", test_content, filename="test_document.txt", content_type="text/plain"
+        )
+
         try:
             async with self.session.post(f"{self.base_url}/upload", data=data) as resp:
                 if resp.status == 200:
                     response_data = await resp.json()
                     document_id = response_data.get("document_id")
                     print_status(f"File upload successful: {document_id}", "success")
-                    self.test_results.append(("File Upload", True, f"Document ID: {document_id}"))
+                    self.test_results.append(
+                        ("File Upload", True, f"Document ID: {document_id}")
+                    )
                     return document_id
                 else:
                     error_text = await resp.text()
-                    print_status(f"File upload failed: {resp.status} - {error_text}", "error")
-                    self.test_results.append(("File Upload", False, f"Status: {resp.status}"))
+                    print_status(
+                        f"File upload failed: {resp.status} - {error_text}", "error"
+                    )
+                    self.test_results.append(
+                        ("File Upload", False, f"Status: {resp.status}")
+                    )
                     return None
-        
+
         except Exception as e:
             print_status(f"File upload error: {e}", "error")
             self.test_results.append(("File Upload", False, str(e)))
             return None
-    
+
     async def test_processing_status(self, document_id: str) -> bool:
         """Test processing status endpoint"""
         if not document_id:
             return False
-        
+
         print_status(f"Testing processing status for {document_id}...", "info")
-        
+
         # Poll status for up to 60 seconds
         for i in range(30):  # 30 attempts, 2 seconds each
             result = await self.test_endpoint(f"/documents/{document_id}/status")
-            
+
             if result["success"]:
                 status_data = result["response"]
                 status = status_data.get("status")
                 progress = status_data.get("progress", 0)
-                
+
                 print_status(f"  Status: {status} ({progress}%)", "info")
-                
+
                 if status == "completed":
                     print_status("Document processing completed!", "success")
-                    self.test_results.append(("Processing Status", True, "Completed successfully"))
+                    self.test_results.append(
+                        ("Processing Status", True, "Completed successfully")
+                    )
                     return True
                 elif status == "failed":
                     error_msg = status_data.get("error", "Unknown error")
                     print_status(f"Document processing failed: {error_msg}", "error")
                     self.test_results.append(("Processing Status", False, error_msg))
                     return False
-                
+
                 # Wait before next poll
                 await asyncio.sleep(2)
             else:
                 print_status(f"Status check failed: {result.get('error')}", "error")
                 break
-        
+
         print_status("Processing status check timed out", "warning")
         self.test_results.append(("Processing Status", False, "Timed out"))
         return False
-    
+
     async def test_document_analysis(self, document_id: str) -> bool:
         """Test document analysis retrieval"""
         if not document_id:
             return False
-        
+
         print_status(f"Testing document analysis for {document_id}...", "info")
-        
+
         result = await self.test_endpoint(f"/documents/{document_id}")
-        
+
         if result["success"]:
             analysis_data = result["response"]
             text_length = len(analysis_data.get("text", ""))
             confidence = analysis_data.get("confidence", 0)
             processing_time = analysis_data.get("processing_time", 0)
-            
-            print_status(f"Analysis retrieved: {text_length} chars, {confidence:.1f}% confidence, {processing_time:.2f}s", "success")
-            self.test_results.append(("Document Analysis", True, f"Text: {text_length} chars"))
+
+            print_status(
+                f"Analysis retrieved: {text_length} chars, {confidence:.1f}% confidence, {processing_time:.2f}s",
+                "success",
+            )
+            self.test_results.append(
+                ("Document Analysis", True, f"Text: {text_length} chars")
+            )
             return True
         else:
             print_status(f"Analysis retrieval failed: {result.get('error')}", "error")
-            self.test_results.append(("Document Analysis", False, result.get('error', 'Failed')))
+            self.test_results.append(
+                ("Document Analysis", False, result.get("error", "Failed"))
+            )
             return False
-    
+
     async def test_document_listing(self) -> bool:
         """Test document listing endpoint"""
         print_status("Testing document listing...", "info")
-        
+
         result = await self.test_endpoint("/documents")
-        
+
         if result["success"]:
             documents = result["response"]
             doc_count = len(documents) if isinstance(documents, list) else 0
@@ -222,77 +244,92 @@ class DeploymentVerifier:
             return True
         else:
             print_status(f"Document listing failed: {result.get('error')}", "error")
-            self.test_results.append(("Document Listing", False, result.get('error', 'Failed')))
+            self.test_results.append(
+                ("Document Listing", False, result.get("error", "Failed"))
+            )
             return False
-    
+
     def print_summary(self):
         """Print test summary"""
-        print_status("\n" + "="*60, "info")
+        print_status("\n" + "=" * 60, "info")
         print_status("DEPLOYMENT VERIFICATION SUMMARY", "info")
-        print_status("="*60, "info")
-        
+        print_status("=" * 60, "info")
+
         passed = sum(1 for _, success, _ in self.test_results if success)
         total = len(self.test_results)
-        
+
         for test_name, success, details in self.test_results:
             status = "✓" if success else "✗"
             color = "success" if success else "error"
             print_status(f"{status} {test_name}: {details}", color)
-        
-        print_status(f"\nResults: {passed}/{total} tests passed", 
-                    "success" if passed == total else "warning")
-        
+
+        print_status(
+            f"\nResults: {passed}/{total} tests passed",
+            "success" if passed == total else "warning",
+        )
+
         if passed == total:
-            print_status("🎉 All tests passed! Your deployment is working correctly.", "success")
+            print_status(
+                "🎉 All tests passed! Your deployment is working correctly.", "success"
+            )
         else:
-            print_status("⚠️  Some tests failed. Check the logs above for details.", "warning")
-        
+            print_status(
+                "⚠️  Some tests failed. Check the logs above for details.", "warning"
+            )
+
         return passed == total
+
 
 async def main():
     """Main verification function"""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Verify Roneira AI deployment")
-    parser.add_argument("--url", default="http://localhost:8000", 
-                       help="Base URL of the deployment (default: http://localhost:8000)")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8000",
+        help="Base URL of the deployment (default: http://localhost:8000)",
+    )
     args = parser.parse_args()
-    
+
     print_status(f"Starting deployment verification for: {args.url}", "info")
-    print_status("="*60 + "\n", "info")
-    
+    print_status("=" * 60 + "\n", "info")
+
     async with DeploymentVerifier(args.url) as verifier:
         # Test health check
         health_ok = await verifier.test_health_check()
-        
+
         if not health_ok:
             print_status("Health check failed. Stopping verification.", "error")
             verifier.print_summary()
             sys.exit(1)
-        
+
         # Test file upload
         document_id = await verifier.test_file_upload()
-        
+
         if document_id:
             # Test processing status
             processing_ok = await verifier.test_processing_status(document_id)
-            
+
             if processing_ok:
                 # Test document analysis
                 await verifier.test_document_analysis(document_id)
-        
+
         # Test document listing
         await verifier.test_document_listing()
-        
+
         # Print summary
         success = verifier.print_summary()
-        
+
         if success:
-            print_status("\n🚀 Your Roneira AI deployment is fully functional!", "success")
+            print_status(
+                "\n🚀 Your Roneira AI deployment is fully functional!", "success"
+            )
             sys.exit(0)
         else:
             print_status("\n❌ Deployment verification failed.", "error")
             sys.exit(1)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import {
     Box,
     Drawer,
@@ -12,55 +12,170 @@ import {
     ListItemIcon,
     ListItemText,
     CssBaseline,
+    IconButton,
+    useMediaQuery,
+    useTheme,
+    Divider,
+    Tooltip,
 } from '@mui/material';
-import { Dashboard as DashboardIcon, UploadFile as UploadFileIcon } from '@mui/icons-material';
+import {
+    Dashboard as DashboardIcon,
+    UploadFile as UploadFileIcon,
+    ForumOutlined as ChatIcon,
+    Menu as MenuIcon,
+    LogoutOutlined as LogoutIcon,
+} from '@mui/icons-material';
+import { microLabel } from '../../../theme';
+import { useAuth } from '../../contexts/AuthContext';
 
-const drawerWidth = 240;
+const DRAWER_WIDTH = 232;
+
+// Chat was reachable only by typing the URL: the product's central feature had
+// no way in. Ordered by how the work actually goes — add documents, ask about
+// them, review what came back.
+const NAV = [
+    { text: 'Upload', icon: <UploadFileIcon fontSize="small" />, path: '/upload' },
+    { text: 'Ask', icon: <ChatIcon fontSize="small" />, path: '/chat' },
+    { text: 'Documents', icon: <DashboardIcon fontSize="small" />, path: '/dashboard' },
+];
 
 const Layout = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const theme = useTheme();
+    const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+    const [mobileOpen, setMobileOpen] = useState(false);
+    const { user, logout } = useAuth();
 
-    const menuItems = [
-        { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
-        { text: 'Upload', icon: <UploadFileIcon />, path: '/upload' },
-    ];
+    const go = (path: string) => {
+        navigate(path);
+        setMobileOpen(false);
+    };
+
+    const nav = (
+        <>
+            <Toolbar />
+            <Box sx={{ px: 2, pt: 2, pb: 1 }}>
+                <Typography sx={microLabel}>Workspace</Typography>
+            </Box>
+            <List sx={{ px: 0 }}>
+                {NAV.map((item) => (
+                    <ListItem key={item.text} disablePadding sx={{ mb: 0.25 }}>
+                        <ListItemButton
+                            onClick={() => go(item.path)}
+                            selected={location.pathname.startsWith(item.path)}
+                        >
+                            <ListItemIcon sx={{ minWidth: 34 }}>{item.icon}</ListItemIcon>
+                            <ListItemText
+                                primary={item.text}
+                                primaryTypographyProps={{ fontSize: '0.875rem', fontWeight: 500 }}
+                            />
+                        </ListItemButton>
+                    </ListItem>
+                ))}
+            </List>
+            <Box sx={{ flexGrow: 1 }} />
+            <Divider />
+            <Box sx={{ p: 2 }}>
+                <Typography sx={microLabel}>Signed in</Typography>
+                <Typography variant="body2" sx={{ mt: 0.5 }}>
+                    {user?.username ?? 'demo'}
+                </Typography>
+            </Box>
+        </>
+    );
 
     return (
-        <Box sx={{ display: 'flex' }}>
+        <Box sx={{ display: 'flex', minHeight: '100vh' }}>
             <CssBaseline />
-            <AppBar
-                position="fixed"
-                sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
-            >
-                <Toolbar>
-                    <Typography variant="h6" noWrap component="div">
-                        Document Intelligence
-                    </Typography>
-                </Toolbar>
-            </AppBar>
-            <Drawer
-                variant="permanent"
+
+            {/* Keyboard users should not have to tab through the whole sidebar
+                on every page to reach the content. */}
+            <Box
+                component="a"
+                href="#main"
                 sx={{
-                    width: drawerWidth,
-                    flexShrink: 0,
-                    [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' },
+                    position: 'absolute',
+                    left: -9999,
+                    zIndex: 2000,
+                    '&:focus': {
+                        left: 8,
+                        top: 8,
+                        px: 2,
+                        py: 1,
+                        bgcolor: 'background.paper',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        color: 'text.primary',
+                    },
                 }}
             >
-                <Toolbar />
-                <Box sx={{ overflow: 'auto' }}>
-                    <List>
-                        {menuItems.map((item) => (
-                            <ListItem key={item.text} disablePadding>
-                                <ListItemButton onClick={() => navigate(item.path)}>
-                                    <ListItemIcon>{item.icon}</ListItemIcon>
-                                    <ListItemText primary={item.text} />
-                                </ListItemButton>
-                            </ListItem>
-                        ))}
-                    </List>
-                </Box>
+                Skip to content
+            </Box>
+
+            <AppBar position="fixed" sx={{ zIndex: theme.zIndex.drawer + 1 }}>
+                <Toolbar sx={{ gap: 1, minHeight: { xs: 56, md: 60 } }}>
+                    {!isDesktop && (
+                        <IconButton
+                            edge="start"
+                            onClick={() => setMobileOpen((open) => !open)}
+                            aria-label="Open navigation"
+                        >
+                            <MenuIcon />
+                        </IconButton>
+                    )}
+                    <Typography
+                        component="div"
+                        sx={{ fontWeight: 600, letterSpacing: '-0.01em', fontSize: '0.9375rem' }}
+                    >
+                        Roneira
+                    </Typography>
+                    <Typography
+                        sx={{ ...microLabel, display: { xs: 'none', sm: 'block' }, mt: '2px' }}
+                    >
+                        Document Intelligence
+                    </Typography>
+                    <Box sx={{ flexGrow: 1 }} />
+                    <Tooltip title="Sign out">
+                        <IconButton onClick={logout} aria-label="Sign out" size="small">
+                            <LogoutIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Toolbar>
+            </AppBar>
+
+            {/* Permanent on desktop, temporary on mobile. The previous drawer
+                was permanent at every width, so on a phone it took a third of
+                the screen and could not be dismissed. */}
+            <Drawer
+                variant={isDesktop ? 'permanent' : 'temporary'}
+                open={isDesktop || mobileOpen}
+                onClose={() => setMobileOpen(false)}
+                ModalProps={{ keepMounted: true }}
+                sx={{
+                    width: { md: DRAWER_WIDTH },
+                    flexShrink: 0,
+                    '& .MuiDrawer-paper': {
+                        width: DRAWER_WIDTH,
+                        boxSizing: 'border-box',
+                        display: 'flex',
+                        flexDirection: 'column',
+                    },
+                }}
+            >
+                {nav}
             </Drawer>
-            <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+
+            <Box
+                component="main"
+                id="main"
+                sx={{
+                    flexGrow: 1,
+                    minWidth: 0, // lets wide tables and code blocks scroll rather than push the page
+                    p: { xs: 2, md: 3 },
+                }}
+            >
                 <Toolbar />
                 <Outlet />
             </Box>

--- a/src/pages/AIChat/AIChat.tsx
+++ b/src/pages/AIChat/AIChat.tsx
@@ -319,12 +319,12 @@ const AIChat = () => {
             display: 'flex', 
             flexDirection: 'column',
             height: '100vh',
-            background: 'linear-gradient(180deg, #0a0f1a 0%, #0f172a 50%, #1e293b 100%)',
+            background: 'linear-gradient(180deg, #0F100E 0%, #0A0B09 50%, #171815 100%)',
         }}>
             {/* Header */}
             <Box sx={{ 
                 p: 2, 
-                borderBottom: '1px solid rgba(99, 102, 241, 0.1)',
+                borderBottom: '1px solid rgba(208, 162, 21, 0.08)',
                 background: 'rgba(10, 15, 26, 0.8)',
                 backdropFilter: 'blur(20px)',
             }}>
@@ -333,10 +333,10 @@ const AIChat = () => {
                         <IconButton onClick={() => navigate('/dashboard')} sx={{ color: 'text.secondary' }}>
                             <ArrowBack />
                         </IconButton>
-                        <AutoAwesome sx={{ color: '#6366f1', fontSize: 28 }} />
+                        <AutoAwesome sx={{ color: '#D0A215', fontSize: 28 }} />
                         <Box>
                             <Typography variant="h6" sx={{ fontWeight: 700, color: 'text.primary' }}>
-                                Roneira <Box component="span" sx={{ color: '#06b6d4' }}>Document Intelligence System</Box>
+                                Roneira <Box component="span" sx={{ color: '#D0A215' }}>Document Intelligence System</Box>
                             </Typography>
                             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                                 {documents.length} verified documents indexed
@@ -350,8 +350,8 @@ const AIChat = () => {
                             onClick={() => setDetailedMode(!detailedMode)}
                             sx={{
                                 background: detailedMode 
-                                    ? 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)'
-                                    : 'rgba(99, 102, 241, 0.2)',
+                                    ? '#D0A215'
+                                    : 'rgba(42, 43, 38, 1)',
                                 color: 'white',
                                 fontWeight: 600,
                                 cursor: 'pointer',
@@ -385,13 +385,13 @@ const AIChat = () => {
                             p: 2.5,
                             borderRadius: message.role === 'user' ? '20px 20px 4px 20px' : '20px 20px 20px 4px',
                             background: message.role === 'user'
-                                ? 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)'
-                                : 'linear-gradient(135deg, rgba(15, 23, 42, 0.9) 0%, rgba(30, 41, 59, 0.7) 100%)',
-                            border: message.role === 'assistant' ? '1px solid rgba(99, 102, 241, 0.2)' : 'none',
+                                ? '#D0A215'
+                                : 'linear-gradient(135deg, rgba(10, 11, 9, 0.9) 0%, rgba(23, 24, 21, 0.7) 100%)',
+                            border: message.role === 'assistant' ? '1px solid rgba(42, 43, 38, 1)' : 'none',
                         }}>
                             {message.isLoading ? (
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                                    <CircularProgress size={20} sx={{ color: '#06b6d4' }} />
+                                    <CircularProgress size={20} sx={{ color: '#D0A215' }} />
                                     <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                                         Analyzing documents...
                                     </Typography>
@@ -421,7 +421,7 @@ const AIChat = () => {
                                                 sx={{
                                                     height: 22,
                                                     fontSize: '0.68rem',
-                                                    color: message.grounded ? '#10b981' : '#f59e0b',
+                                                    color: message.grounded ? '#7A9A5B' : '#C9922B',
                                                     borderColor: message.grounded ? 'rgba(16,185,129,0.4)' : 'rgba(245,158,11,0.4)',
                                                     background: message.grounded ? 'rgba(16,185,129,0.1)' : 'rgba(245,158,11,0.1)',
                                                 }}
@@ -437,7 +437,7 @@ const AIChat = () => {
                                                         sx={{
                                                             height: 22,
                                                             fontSize: '0.68rem',
-                                                            color: '#f59e0b',
+                                                            color: '#C9922B',
                                                             borderColor: 'rgba(245,158,11,0.4)',
                                                             background: 'rgba(245,158,11,0.1)',
                                                         }}
@@ -449,8 +449,8 @@ const AIChat = () => {
 
                                     {/* Document References */}
                                     {message.references && message.references.length > 0 && (
-                                        <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid rgba(99, 102, 241, 0.2)' }}>
-                                            <Typography variant="caption" sx={{ color: '#06b6d4', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid rgba(42, 43, 38, 1)' }}>
+                                            <Typography variant="caption" sx={{ color: '#D0A215', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
                                                 <Description sx={{ fontSize: 16 }} />
                                                 Sources ({message.references.length})
                                             </Typography>
@@ -462,8 +462,8 @@ const AIChat = () => {
                                                         sx={{
                                                             p: 1.5,
                                                             borderRadius: 2,
-                                                            background: 'rgba(99, 102, 241, 0.1)',
-                                                            border: '1px solid rgba(99, 102, 241, 0.15)',
+                                                            background: 'rgba(208, 162, 21, 0.08)',
+                                                            border: '1px solid rgba(42, 43, 38, 1)',
                                                             cursor: 'pointer',
                                                         }}
                                                     >
@@ -479,7 +479,7 @@ const AIChat = () => {
                                                                         width: 24,
                                                                         height: 24,
                                                                         fontSize: '0.7rem',
-                                                                        background: '#6366f1'
+                                                                        background: '#D0A215'
                                                                     }}
                                                                 />
                                                                 <Typography variant="body2" sx={{ fontWeight: 500, color: 'text.primary' }}>
@@ -491,7 +491,7 @@ const AIChat = () => {
                                                                         label={`p. ${ref.page_number}`}
                                                                         size="small"
                                                                         variant="outlined"
-                                                                        sx={{ height: 20, fontSize: '0.65rem', color: '#06b6d4', borderColor: 'rgba(6,182,212,0.4)' }}
+                                                                        sx={{ height: 20, fontSize: '0.65rem', color: '#D0A215', borderColor: 'rgba(6,182,212,0.4)' }}
                                                                     />
                                                                 )}
                                                                 <Typography variant="caption" sx={{ color: 'text.secondary' }}>
@@ -506,7 +506,7 @@ const AIChat = () => {
                                                                             e.stopPropagation();
                                                                             handleDownload(ref.document_id, ref.filename ?? ref.document_id);
                                                                         }}
-                                                                        sx={{ color: '#06b6d4', mr: 1 }}
+                                                                        sx={{ color: '#D0A215', mr: 1 }}
                                                                     >
                                                                         <Download fontSize="small" />
                                                                     </IconButton>
@@ -577,7 +577,7 @@ const AIChat = () => {
             {/* Input Area */}
             <Box sx={{ 
                 p: 3,
-                borderTop: '1px solid rgba(99, 102, 241, 0.1)',
+                borderTop: '1px solid rgba(208, 162, 21, 0.08)',
                 background: 'rgba(10, 15, 26, 0.8)',
                 backdropFilter: 'blur(20px)',
             }}>
@@ -588,11 +588,11 @@ const AIChat = () => {
                     p: 1,
                     pl: 2,
                     borderRadius: 4,
-                    background: 'rgba(15, 23, 42, 0.8)',
-                    border: '2px solid rgba(99, 102, 241, 0.2)',
+                    background: 'rgba(10, 11, 9, 0.8)',
+                    border: '2px solid rgba(42, 43, 38, 1)',
                     '&:focus-within': {
-                        border: '2px solid rgba(99, 102, 241, 0.5)',
-                        boxShadow: '0 0 20px rgba(99, 102, 241, 0.2)',
+                        border: '2px solid rgba(208, 162, 21, 0.5)',
+                        boxShadow: '0 0 20px rgba(42, 43, 38, 1)',
                     }
                 }}>
                     <TextField
@@ -624,13 +624,13 @@ const AIChat = () => {
                         onClick={handleSend}
                         disabled={!inputValue.trim() || isLoading}
                         sx={{ 
-                            background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
+                            background: '#D0A215',
                             color: 'white',
                             '&:hover': {
-                                background: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
+                                background: '#B58E12',
                             },
                             '&:disabled': {
-                                background: 'rgba(99, 102, 241, 0.3)',
+                                background: 'rgba(42, 43, 38, 1)',
                                 color: 'rgba(255,255,255,0.5)',
                             }
                         }}
@@ -648,8 +648,8 @@ const AIChat = () => {
                 PaperProps={{
                     sx: {
                         width: 320,
-                        background: 'linear-gradient(180deg, #0f172a 0%, #1e293b 100%)',
-                        borderLeft: '1px solid rgba(99, 102, 241, 0.2)',
+                        background: 'linear-gradient(180deg, #0A0B09 0%, #171815 100%)',
+                        borderLeft: '1px solid rgba(42, 43, 38, 1)',
                         p: 3
                     }
                 }}
@@ -666,7 +666,7 @@ const AIChat = () => {
                         <Switch 
                             checked={ragEnabled} 
                             onChange={(e) => setRagEnabled(e.target.checked)}
-                            sx={{ '& .MuiSwitch-thumb': { bgcolor: '#6366f1' } }}
+                            sx={{ '& .MuiSwitch-thumb': { bgcolor: '#D0A215' } }}
                         />
                     }
                     label={<Typography sx={{ color: 'text.primary' }}>Enable RAG</Typography>}
@@ -684,7 +684,7 @@ const AIChat = () => {
                     min={0}
                     max={1}
                     step={0.1}
-                    sx={{ color: '#6366f1', mb: 3 }}
+                    sx={{ color: '#D0A215', mb: 3 }}
                 />
                 <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 3 }}>
                     Lower = more focused, Higher = more creative
@@ -698,7 +698,7 @@ const AIChat = () => {
                     min={128}
                     max={2048}
                     step={128}
-                    sx={{ color: '#06b6d4', mb: 3 }}
+                    sx={{ color: '#D0A215', mb: 3 }}
                 />
                 <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 3 }}>
                     Maximum response length
@@ -711,11 +711,11 @@ const AIChat = () => {
                 <Chip 
                     label="llama3.2:3b" 
                     size="small" 
-                    sx={{ bgcolor: 'rgba(99, 102, 241, 0.2)', color: '#6366f1', mb: 3 }}
+                    sx={{ bgcolor: 'rgba(42, 43, 38, 1)', color: '#D0A215', mb: 3 }}
                 />
                 
                 <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>Session ID</Typography>
-                <Typography variant="caption" sx={{ color: '#06b6d4', fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                <Typography variant="caption" sx={{ color: '#D0A215', fontFamily: 'monospace', wordBreak: 'break-all' }}>
                     {sessionId}
                 </Typography>
                 
@@ -724,7 +724,7 @@ const AIChat = () => {
                         fullWidth 
                         variant="outlined" 
                         onClick={() => setSettingsOpen(false)}
-                        sx={{ borderColor: 'rgba(99, 102, 241, 0.3)', color: 'text.primary' }}
+                        sx={{ borderColor: 'rgba(42, 43, 38, 1)', color: 'text.primary' }}
                     >
                         Close
                     </Button>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
     Memory
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import { apiClient } from '../../api/client';
 
 // ==============================================================================
 // Roneira AI - Data Insights Plus Dashboard
@@ -75,9 +76,9 @@ const MetricCard = ({ title, value, subValue, icon, trend, gradient, glowColor, 
                         sx={{ 
                             height: 24, 
                             fontWeight: 600,
-                            background: trend.isPositive ? 'rgba(16, 185, 129, 0.15)' : 'rgba(239, 68, 68, 0.15)', 
-                            color: trend.isPositive ? '#10b981' : '#ef4444',
-                            border: `1px solid ${trend.isPositive ? 'rgba(16, 185, 129, 0.2)' : 'rgba(239, 68, 68, 0.2)'}`
+                            background: trend.isPositive ? 'rgba(122, 154, 91, 0.15)' : 'rgba(194, 94, 63, 0.15)', 
+                            color: trend.isPositive ? '#7A9A5B' : '#C25E3F',
+                            border: `1px solid ${trend.isPositive ? 'rgba(122, 154, 91, 0.2)' : 'rgba(194, 94, 63, 0.2)'}`
                         }} 
                     />
                 )}
@@ -140,36 +141,45 @@ const Dashboard = () => {
     const [metrics, setMetrics] = useState<any>(null);
     const [loading, setLoading] = useState(true);
     
-    // Theme Gradients
+    // Flat accents rather than two-hue gradients. A gradient from ochre to
+    // purple says nothing about the number underneath it, and the palette only
+    // has one accent to spend — on provenance.
     const gradients = {
-        primary: 'linear-gradient(135deg, #6366f1 0%, #a855f7 100%)',
-        info: 'linear-gradient(135deg, #3b82f6 0%, #06b6d4 100%)',
-        success: 'linear-gradient(135deg, #10b981 0%, #84cc16 100%)',
-        warning: 'linear-gradient(135deg, #f59e0b 0%, #f97316 100%)',
-        error: 'linear-gradient(135deg, #ef4444 0%, #be123c 100%)',
-        dark: 'linear-gradient(135deg, #0f172a 0%, #334155 100%)'
+        primary: '#D0A215',
+        info: '#5E7A8A',
+        success: '#7A9A5B',
+        warning: '#C25E3F',
+        error: '#C25E3F',
+        dark: '#2A2B26'
     };
-    
+
     const glows = {
-        primary: '0 0 30px rgba(99, 102, 241, 0.4)',
-        info: '0 0 30px rgba(6, 182, 212, 0.4)',
-        success: '0 0 30px rgba(16, 185, 129, 0.4)',
-        warning: '0 0 30px rgba(245, 158, 11, 0.4)',
+        primary: '0 0 24px rgba(208, 162, 21, 0.18)',
+        info: '0 0 24px rgba(94, 122, 138, 0.18)',
+        success: '0 0 24px rgba(122, 154, 91, 0.18)',
+        warning: '0 0 24px rgba(194, 94, 63, 0.18)',
     };
 
     const fetchData = async () => {
         try {
-            const [docsRes, healthRes, metricsRes] = await Promise.all([
-                fetch('/api/documents?limit=100'),
-                fetch('/health'), // Might need /api/health depending on backend routing, assuming root health check
-                fetch('/api/dashboard/metrics')
+            // apiClient, not fetch: document endpoints require a bearer token
+            // and bare fetch sends none, so every request 401'd and the whole
+            // dashboard rendered zeros against a full index.
+            //
+            // Health is deliberately the one exception — it is unauthenticated
+            // and must stay readable even when a token has expired, which is
+            // exactly when you want to know what is wrong.
+            const [docsRes, healthRes, metricsRes] = await Promise.allSettled([
+                apiClient.get('/documents?limit=100'),
+                apiClient.get('/health'),
+                apiClient.get('/dashboard/metrics'),
             ]);
-            if (docsRes.ok) {
-                const data = await docsRes.json();
-                setDocuments(data.documents || []);
+
+            if (docsRes.status === 'fulfilled') {
+                setDocuments(docsRes.value.data?.documents ?? []);
             }
-            if (healthRes.ok) setHealth(await healthRes.json());
-            if (metricsRes.ok) setMetrics(await metricsRes.json());
+            if (healthRes.status === 'fulfilled') setHealth(healthRes.value.data);
+            if (metricsRes.status === 'fulfilled') setMetrics(metricsRes.value.data);
             setLoading(false);
         } catch (error) {
             console.error(error);
@@ -207,12 +217,12 @@ const Dashboard = () => {
     const storageUsed = (documents.reduce((acc, d) => acc + (d.file_size || 0), 0) / 1024 / 1024).toFixed(2);
 
     return (
-        <Box sx={{ flexGrow: 1, p: { xs: 2, md: 4, lg: 5 }, minHeight: '100vh', background: '#0a0f1a' }}>
+        <Box sx={{ flexGrow: 1, p: { xs: 2, md: 4, lg: 5 }, minHeight: '100vh', background: '#0F100E' }}>
             {/* Header */}
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 5 }}>
                 <Box>
                     <Typography variant="h4" sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 1, color: 'white' }}>
-                        Data Insights <Box component="span" sx={{ color: '#06b6d4' }}>Plus</Box>
+                        Data Insights <Box component="span" sx={{ color: '#D0A215' }}>Plus</Box>
                     </Typography>
                     <Typography variant="body1" sx={{ color: 'text.secondary', fontWeight: 500 }}>
                         Real-time intelligence dashboard & system telemetry
@@ -266,7 +276,7 @@ const Dashboard = () => {
                     <MetricCard 
                         title="AI Accuracy Score" 
                         value={`${accuracy}%`} 
-                        icon={<VerifiedUser sx={{ color: '#10b981' }} />} 
+                        icon={<VerifiedUser sx={{ color: '#7A9A5B' }} />} 
                         gradient={gradients.success} 
                         glowColor={glows.success} 
                         loading={loading} 
@@ -276,7 +286,7 @@ const Dashboard = () => {
                     <MetricCard 
                         title="Avg Process Time" 
                         value={avgTime} 
-                        icon={<Speed sx={{ color: '#06b6d4' }} />} 
+                        icon={<Speed sx={{ color: '#D0A215' }} />} 
                         gradient={gradients.info} 
                         glowColor={glows.info} 
                         loading={loading} 
@@ -287,7 +297,7 @@ const Dashboard = () => {
                         title="Storage Used" 
                         value={storageUsed} 
                         subValue="MB"
-                        icon={<Memory sx={{ color: '#f59e0b' }} />} 
+                        icon={<Memory sx={{ color: '#C9922B' }} />} 
                         gradient={gradients.warning} 
                         glowColor={glows.warning} 
                         loading={loading} 
@@ -299,17 +309,17 @@ const Dashboard = () => {
             <Grid container spacing={3}>
                 {/* Document Type Distribution */}
                 <Grid item xs={12} md={4}>
-                    <Card sx={{ height: '100%', background: 'rgba(15, 23, 42, 0.6)', backdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,0.05)' }}>
+                    <Card sx={{ height: '100%', background: 'rgba(10, 11, 9, 0.6)', backdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,0.05)' }}>
                         <CardContent sx={{ p: 4 }}>
                             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 4 }}>
                                 <Typography variant="h6" sx={{ fontWeight: 700, color: 'white' }}>Corpus Distribution</Typography>
                                 <PieChart sx={{ color: 'text.secondary' }} />
                             </Box>
                             
-                            <DistributionBar label="Finance & Invoices" value={total > 0 ? ((types['Finance'] || 0) / total) * 100 : 0} count={types['Finance'] || 0} color="#6366f1" />
-                            <DistributionBar label="Human Resources" value={total > 0 ? ((types['HR'] || 0) / total) * 100 : 0} count={types['HR'] || 0} color="#10b981" />
-                            <DistributionBar label="Engineering" value={total > 0 ? ((types['Engineering'] || 0) / total) * 100 : 0} count={types['Engineering'] || 0} color="#f59e0b" />
-                            <DistributionBar label="Uncategorized" value={total > 0 ? ((types['General'] || 0) / total) * 100 : 0} count={types['General'] || 0} color="#94a3b8" />
+                            <DistributionBar label="Finance & Invoices" value={total > 0 ? ((types['Finance'] || 0) / total) * 100 : 0} count={types['Finance'] || 0} color="#D0A215" />
+                            <DistributionBar label="Human Resources" value={total > 0 ? ((types['HR'] || 0) / total) * 100 : 0} count={types['HR'] || 0} color="#7A9A5B" />
+                            <DistributionBar label="Engineering" value={total > 0 ? ((types['Engineering'] || 0) / total) * 100 : 0} count={types['Engineering'] || 0} color="#C9922B" />
+                            <DistributionBar label="Uncategorized" value={total > 0 ? ((types['General'] || 0) / total) * 100 : 0} count={types['General'] || 0} color="#95907F" />
                             
                             <Divider sx={{ my: 3, borderColor: 'rgba(255,255,255,0.1)' }} />
                             
@@ -327,12 +337,12 @@ const Dashboard = () => {
                     <Grid container spacing={3}>
                         {/* System Status */}
                         <Grid item xs={12}>
-                            <Card sx={{ background: 'linear-gradient(135deg, rgba(16, 185, 129, 0.1) 0%, rgba(6, 182, 212, 0.1) 100%)', border: '1px solid rgba(16, 185, 129, 0.2)' }}>
+                            <Card sx={{ background: 'linear-gradient(135deg, rgba(122, 154, 91, 0.1) 0%, rgba(6, 182, 212, 0.1) 100%)', border: '1px solid rgba(122, 154, 91, 0.2)' }}>
                                 <CardContent sx={{ p: 3, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                         <Box sx={{ position: 'relative' }}>
-                                            <Box sx={{ width: 12, height: 12, borderRadius: '50%', background: '#10b981', boxShadow: '0 0 10px #10b981' }} />
-                                            <Box sx={{ position: 'absolute', top: -4, left: -4, right: -4, bottom: -4, borderRadius: '50%', border: '2px solid rgba(16, 185, 129, 0.3)', animation: 'pulse 2s infinite' }} />
+                                            <Box sx={{ width: 12, height: 12, borderRadius: '50%', background: '#7A9A5B', boxShadow: '0 0 10px #7A9A5B' }} />
+                                            <Box sx={{ position: 'absolute', top: -4, left: -4, right: -4, bottom: -4, borderRadius: '50%', border: '2px solid rgba(122, 154, 91, 0.3)', animation: 'pulse 2s infinite' }} />
                                         </Box>
                                         <Box>
                                             <Typography variant="h6" sx={{ fontWeight: 700, color: 'white' }}>All Systems Operational</Typography>
@@ -344,17 +354,17 @@ const Dashboard = () => {
                                     <Box sx={{ display: 'flex', gap: 3 }}>
                                         <Box sx={{ textAlign: 'right' }}>
                                             <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>Database</Typography>
-                                            <Typography variant="body1" sx={{ fontWeight: 600, color: health?.database_status === 'connected' ? '#10b981' : '#ef4444' }}>
+                                            <Typography variant="body1" sx={{ fontWeight: 600, color: health?.database_status === 'connected' ? '#7A9A5B' : '#C25E3F' }}>
                                                 {health?.database_status || '-'}
                                             </Typography>
                                         </Box>
                                         <Box sx={{ textAlign: 'right' }}>
                                             <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>Processing Queue</Typography>
-                                            <Typography variant="body1" sx={{ fontWeight: 600, color: '#06b6d4' }}>{processing} jobs</Typography>
+                                            <Typography variant="body1" sx={{ fontWeight: 600, color: '#D0A215' }}>{processing} jobs</Typography>
                                         </Box>
                                         <Box sx={{ textAlign: 'right' }}>
                                             <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>Services</Typography>
-                                            <Typography variant="body1" sx={{ fontWeight: 600, color: health?.services_status === 'operational' ? '#a855f7' : '#f59e0b' }}>
+                                            <Typography variant="body1" sx={{ fontWeight: 600, color: health?.services_status === 'operational' ? '#a855f7' : '#C9922B' }}>
                                                 {health?.services_status || '-'}
                                             </Typography>
                                         </Box>
@@ -365,7 +375,7 @@ const Dashboard = () => {
 
                         {/* Recent Activity Feed */}
                         <Grid item xs={12}>
-                            <Card sx={{ background: 'rgba(15, 23, 42, 0.6)', backdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,0.05)' }}>
+                            <Card sx={{ background: 'rgba(10, 11, 9, 0.6)', backdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,0.05)' }}>
                                 <CardContent sx={{ p: 4 }}>
                                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
                                         <Typography variant="h6" sx={{ fontWeight: 700, color: 'white' }}>Live Processing Feed</Typography>
@@ -377,7 +387,7 @@ const Dashboard = () => {
                                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                                 <Box sx={{ 
                                                     width: 40, height: 40, borderRadius: 2, 
-                                                    background: 'rgba(99, 102, 241, 0.1)', color: '#6366f1',
+                                                    background: 'rgba(208, 162, 21, 0.08)', color: '#D0A215',
                                                     display: 'flex', alignItems: 'center', justifyContent: 'center'
                                                 }}>
                                                     <Article fontSize="small" />
@@ -394,8 +404,8 @@ const Dashboard = () => {
                                                 size="small" 
                                                 sx={{ 
                                                     fontWeight: 700, fontSize: '0.7rem',
-                                                    background: doc.is_processed ? 'rgba(16, 185, 129, 0.1)' : 'rgba(245, 158, 11, 0.1)',
-                                                    color: doc.is_processed ? '#10b981' : '#f59e0b'
+                                                    background: doc.is_processed ? 'rgba(122, 154, 91, 0.1)' : 'rgba(201, 146, 43, 0.1)',
+                                                    color: doc.is_processed ? '#7A9A5B' : '#C9922B'
                                                 }} 
                                             />
                                         </Box>

--- a/src/pages/DocumentViewer/DocumentViewer.tsx
+++ b/src/pages/DocumentViewer/DocumentViewer.tsx
@@ -59,6 +59,10 @@ interface ComparisonChange {
     right_page?: number | null;
 }
 
+/** "1 pages" is the sort of thing that makes an interface look unfinished. */
+const plural = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
 const CHANGE_COLOURS: Record<string, string> = {
     added: '#10b981',
     removed: '#ef4444',
@@ -219,15 +223,15 @@ const DocumentViewer = () => {
                         color={documentData.status === 'completed' ? 'success' : 'default'}
                     />
                     {documentData.page_count ? (
-                        <Chip size="small" variant="outlined" label={`${documentData.page_count} pages`} />
+                        <Chip size="small" variant="outlined" label={plural(documentData.page_count, 'page')} />
                     ) : null}
                     {documentData.word_count ? (
-                        <Chip size="small" variant="outlined" label={`${documentData.word_count} words`} />
+                        <Chip size="small" variant="outlined" label={plural(documentData.word_count, 'word')} />
                     ) : null}
                     <Chip
                         size="small"
                         variant="outlined"
-                        label={`${documentData.chunk_count ?? 0} searchable chunks`}
+                        label={plural(documentData.chunk_count ?? 0, 'searchable chunk')}
                     />
 
                     {/* Machine-read pages are worth flagging: OCR quality is

--- a/src/pages/DocumentViewer/DocumentViewer.tsx
+++ b/src/pages/DocumentViewer/DocumentViewer.tsx
@@ -64,8 +64,8 @@ const plural = (count: number, noun: string) =>
     `${count} ${noun}${count === 1 ? '' : 's'}`;
 
 const CHANGE_COLOURS: Record<string, string> = {
-    added: '#10b981',
-    removed: '#ef4444',
+    added: '#7A9A5B',
+    removed: '#C25E3F',
     changed: '#f59e0b',
 };
 

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -1,17 +1,34 @@
 import { css } from '@emotion/react';
 
+// Only what the MUI theme cannot reach. Everything else lives in theme.ts so
+// there is one place to change a colour.
 export const globalStyles = css`
-  body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-      sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  html {
+    /* Anchors and in-page jumps land below the fixed app bar rather than
+       underneath it. */
+    scroll-padding-top: 80px;
   }
 
-  code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
+  body {
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  /* Verbatim document material is monospaced everywhere it appears — that is
+     how you tell what the document said from what the interface says. */
+  code,
+  pre,
+  samp {
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', 'Cascadia Mono',
+      Consolas, 'Liberation Mono', monospace;
+    font-size: 0.8125rem;
+  }
+
+  /* Long identifiers and URLs should wrap rather than widen the page. */
+  pre {
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 `;

--- a/theme.ts
+++ b/theme.ts
@@ -1,354 +1,272 @@
 import { createTheme, alpha } from '@mui/material/styles';
 
 // ==============================================================================
-// Roneira AI - Modern 2026 Dark Theme
-// Figma-Inspired Glassmorphism Design with Deep Slate Background
+// Roneira — "archive"
+//
+// This is an instrument for checking claims against documents, used where
+// being wrong is expensive. So it borrows from archives and annotated legal
+// paper rather than from dashboards: warm ink and vellum instead of slate and
+// neon, hairline rules instead of glass, and one reserved accent.
+//
+// The previous theme was indigo-and-purple glassmorphism on Tailwind slate —
+// competent, and indistinguishable from every other AI product. Worse, it
+// spent colour on decoration, which left nothing to say "this passage is
+// verified" with.
+//
+// Two rules hold the whole system together:
+//
+//   1. OCHRE MEANS PROVENANCE. The accent is reserved for grounding and
+//      citations. If something is ochre, it is a claim you can check.
+//      Nothing decorative may use it.
+//   2. EVIDENCE IS MONOSPACED. Verbatim material from a document — quoted
+//      passages, page numbers, checksums, IDs — is always mono. The app's own
+//      words are always sans. You can tell them apart without reading.
+//
+// No webfonts. The product runs offline by design, and a font CDN would be a
+// network dependency that fails exactly when someone is working on a plane.
+// Character comes from scale, weight and tracking instead.
 // ==============================================================================
 
-// --- Premium Dark Color Palette ---
-const colors = {
-  primary: {
-    main: '#6366f1', // Vibrant indigo
-    light: '#818cf8',
-    dark: '#4f46e5',
-    contrastText: '#ffffff',
-  },
-  secondary: {
-    main: '#8b5cf6', // Rich purple
-    light: '#a78bfa',
-    dark: '#7c3aed',
-    contrastText: '#ffffff',
-  },
-  success: {
-    main: '#10b981', // Emerald
-    light: '#34d399',
-    dark: '#059669',
-  },
-  warning: {
-    main: '#f59e0b', // Amber
-    light: '#fbbf24',
-    dark: '#d97706',
-  },
-  error: {
-    main: '#ef4444', // Red
-    light: '#f87171',
-    dark: '#dc2626',
-  },
-  info: {
-    main: '#06b6d4', // Cyan accent
-    light: '#22d3ee',
-    dark: '#0891b2',
-  },
-  background: {
-    default: '#0a0f1a', // Deep dark
-    paper: '#0f172a',   // Slate 900
-  },
-  text: {
-    primary: '#f1f5f9',   // Slate 100
-    secondary: '#94a3b8', // Slate 400
-  },
+const palette = {
+  // Printer's ink: near-black with a warm cast, not blue-grey.
+  ink: '#0F100E',
+  inkRaised: '#171815',
+  inkSunken: '#0A0B09',
+  // Warm off-white. Long reading sessions; paper, not screen-blue.
+  vellum: '#E9E5DA',
+  graphite: '#95907F',
+  rule: '#2A2B26',
+  // Reserved: provenance, citations, verified grounding.
+  ochre: '#D0A215',
+  ochreDim: '#8A6D0E',
+  // Annotation red — degraded modes, destructive actions.
+  oxide: '#C25E3F',
+  moss: '#7A9A5B',
+  slate: '#5E7A8A',
 };
 
-// --- Glassmorphism Card Styles ---
-export const glassCard = {
-  background: 'linear-gradient(135deg, rgba(15, 23, 42, 0.8) 0%, rgba(30, 41, 59, 0.6) 100%)',
-  backdropFilter: 'blur(20px)',
-  WebkitBackdropFilter: 'blur(20px)',
-  border: '1px solid rgba(99, 102, 241, 0.15)',
-  boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.05)',
+const SANS = [
+  'system-ui',
+  '-apple-system',
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  'Arial',
+  'sans-serif',
+].join(',');
+
+// Evidence face. ui-monospace resolves to SF Mono / Cascadia / Consolas, all
+// of which are already on the machine.
+const MONO = [
+  'ui-monospace',
+  'SFMono-Regular',
+  'SF Mono',
+  'Cascadia Mono',
+  'Consolas',
+  'Liberation Mono',
+  'monospace',
+].join(',');
+
+export const evidenceFont = MONO;
+
+/** Verbatim document text. The signature treatment — use it for anything the
+ *  document said, never for anything the interface says. */
+export const evidence = {
+  fontFamily: MONO,
+  fontSize: '0.8125rem',
+  lineHeight: 1.65,
+  color: palette.vellum,
+  borderLeft: `2px solid ${palette.ochreDim}`,
+  paddingLeft: 12,
+  whiteSpace: 'pre-wrap' as const,
 };
 
-// --- Glowing Accent Styles ---
-export const glowEffect = {
-  primary: '0 0 20px rgba(99, 102, 241, 0.4), 0 0 40px rgba(99, 102, 241, 0.2)',
-  cyan: '0 0 20px rgba(6, 182, 212, 0.4), 0 0 40px rgba(6, 182, 212, 0.2)',
-  success: '0 0 20px rgba(16, 185, 129, 0.4), 0 0 40px rgba(16, 185, 129, 0.2)',
+/** Small uppercase label. Archival vernacular: wide tracking, low contrast. */
+export const microLabel = {
+  fontFamily: SANS,
+  fontSize: '0.6875rem',
+  fontWeight: 600,
+  letterSpacing: '0.09em',
+  textTransform: 'uppercase' as const,
+  color: palette.graphite,
 };
 
-// --- Dark Theme Configuration ---
+/** Panels are defined by a hairline rule, not by a shadow or a blur. */
+export const panel = {
+  background: palette.inkRaised,
+  border: `1px solid ${palette.rule}`,
+  borderRadius: 6,
+};
+
 export const theme = createTheme({
   palette: {
     mode: 'dark',
-    ...colors,
+    primary: { main: palette.ochre, dark: palette.ochreDim, contrastText: palette.ink },
+    secondary: { main: palette.slate, contrastText: palette.vellum },
+    success: { main: palette.moss },
+    warning: { main: palette.oxide },
+    error: { main: palette.oxide },
+    info: { main: palette.slate },
+    background: { default: palette.ink, paper: palette.inkRaised },
+    text: { primary: palette.vellum, secondary: palette.graphite },
+    divider: palette.rule,
   },
-  
+
+  shape: { borderRadius: 6 },
+
   typography: {
-    fontFamily: '"Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, sans-serif',
-    h1: { 
-      fontSize: '2.5rem', 
-      fontWeight: 700,
-      letterSpacing: '-0.02em',
-      color: colors.text.primary,
-    },
-    h2: { 
-      fontSize: '2rem', 
-      fontWeight: 700,
-      letterSpacing: '-0.01em',
-    },
-    h3: { 
-      fontSize: '1.5rem', 
-      fontWeight: 600,
-    },
-    h4: {
-      fontSize: '1.25rem',
-      fontWeight: 600,
-    },
-    h5: {
-      fontSize: '1rem',
-      fontWeight: 600,
-    },
-    h6: {
-      fontSize: '0.875rem',
-      fontWeight: 600,
-      textTransform: 'uppercase',
-      letterSpacing: '0.5px',
-    },
-    body1: {
-      fontSize: '0.9375rem',
-      lineHeight: 1.6,
-    },
-    body2: {
-      fontSize: '0.8125rem',
-      lineHeight: 1.5,
-      color: colors.text.secondary,
-    },
-    button: {
-      textTransform: 'none',
-      fontWeight: 600,
-      letterSpacing: '0.02em',
-    },
+    fontFamily: SANS,
+    // Display sizes are tightened; body stays comfortable. The contrast
+    // between the two is where the personality lives without a webfont.
+    h1: { fontSize: '2.25rem', fontWeight: 600, letterSpacing: '-0.025em', lineHeight: 1.15 },
+    h2: { fontSize: '1.75rem', fontWeight: 600, letterSpacing: '-0.02em', lineHeight: 1.2 },
+    h3: { fontSize: '1.375rem', fontWeight: 600, letterSpacing: '-0.015em' },
+    h4: { fontSize: '1.175rem', fontWeight: 600, letterSpacing: '-0.01em' },
+    h5: { fontSize: '1.0625rem', fontWeight: 600 },
+    h6: { fontSize: '0.9375rem', fontWeight: 600, letterSpacing: '0.005em' },
+    body1: { fontSize: '0.9375rem', lineHeight: 1.65 },
+    body2: { fontSize: '0.875rem', lineHeight: 1.6 },
+    caption: { fontSize: '0.75rem', lineHeight: 1.5, color: palette.graphite },
+    button: { textTransform: 'none', fontWeight: 600, letterSpacing: '0.01em' },
   },
-
-  shape: { borderRadius: 16 },
-
-  shadows: [
-    'none',
-    '0 2px 8px rgba(0, 0, 0, 0.3)',
-    '0 4px 12px rgba(0, 0, 0, 0.35)',
-    '0 6px 16px rgba(0, 0, 0, 0.4)',
-    '0 8px 24px rgba(0, 0, 0, 0.4)',
-    '0 12px 32px rgba(0, 0, 0, 0.45)',
-    '0 16px 40px rgba(0, 0, 0, 0.5)',
-    ...Array(18).fill('none'),
-  ] as any,
 
   components: {
     MuiCssBaseline: {
-      styleOverrides: `
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-        
-        :root {
-          --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-          --gradient-cyan: linear-gradient(135deg, #06b6d4 0%, #10b981 100%);
-          --glass-bg: rgba(15, 23, 42, 0.8);
-          --glass-border: rgba(99, 102, 241, 0.15);
-        }
-        
-        body {
-          background: linear-gradient(180deg, #0a0f1a 0%, #0f172a 50%, #1e293b 100%);
-          min-height: 100vh;
-        }
-        
-        ::-webkit-scrollbar {
-          width: 6px;
-          height: 6px;
-        }
-        
-        ::-webkit-scrollbar-track {
-          background: rgba(15, 23, 42, 0.5);
-        }
-        
-        ::-webkit-scrollbar-thumb {
-          background: rgba(99, 102, 241, 0.4);
-          border-radius: 3px;
-        }
-        
-        ::-webkit-scrollbar-thumb:hover {
-          background: rgba(99, 102, 241, 0.6);
-        }
-        
-        ::selection {
-          background: rgba(99, 102, 241, 0.4);
-        }
-      `,
-    },
-    
-    MuiButton: {
       styleOverrides: {
-        root: {
-          borderRadius: 12,
-          padding: '12px 28px',
-          fontSize: '0.9375rem',
-          fontWeight: 600,
-          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        // Keyboard focus must always be visible, and it uses the accent
+        // because "where am I" is a question about provenance too.
+        '*:focus-visible': {
+          outline: `2px solid ${palette.ochre}`,
+          outlineOffset: 2,
+          borderRadius: 3,
         },
-        contained: {
-          background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
-          boxShadow: '0 4px 16px rgba(99, 102, 241, 0.3)',
-          '&:hover': {
-            background: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
-            boxShadow: '0 8px 24px rgba(99, 102, 241, 0.4)',
-            transform: 'translateY(-2px)',
+        '::selection': {
+          background: alpha(palette.ochre, 0.3),
+          color: palette.vellum,
+        },
+        // Respect the OS setting rather than animating regardless.
+        '@media (prefers-reduced-motion: reduce)': {
+          '*': {
+            animationDuration: '0.01ms !important',
+            transitionDuration: '0.01ms !important',
+            scrollBehavior: 'auto !important',
           },
         },
-        outlined: {
-          borderColor: 'rgba(99, 102, 241, 0.5)',
-          borderWidth: 2,
-          '&:hover': {
-            borderWidth: 2,
-            borderColor: '#6366f1',
-            background: 'rgba(99, 102, 241, 0.1)',
-          },
+        body: { backgroundColor: palette.ink },
+        // Scrollbars that belong to the palette instead of the OS default.
+        '*::-webkit-scrollbar': { width: 10, height: 10 },
+        '*::-webkit-scrollbar-track': { background: palette.inkSunken },
+        '*::-webkit-scrollbar-thumb': {
+          background: palette.rule,
+          borderRadius: 5,
+          border: `2px solid ${palette.inkSunken}`,
         },
+        '*::-webkit-scrollbar-thumb:hover': { background: palette.graphite },
       },
     },
-    
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          background: 'linear-gradient(135deg, rgba(15, 23, 42, 0.9) 0%, rgba(30, 41, 59, 0.7) 100%)',
-          backdropFilter: 'blur(20px)',
-          WebkitBackdropFilter: 'blur(20px)',
-          border: '1px solid rgba(99, 102, 241, 0.1)',
-          borderRadius: 20,
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
-          transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
-          '&:hover': {
-            border: '1px solid rgba(99, 102, 241, 0.3)',
-            boxShadow: '0 16px 48px rgba(0, 0, 0, 0.5), 0 0 40px rgba(99, 102, 241, 0.1)',
-            transform: 'translateY(-4px)',
-          },
-        },
-      },
-    },
-    
+
     MuiPaper: {
       styleOverrides: {
         root: {
-          background: 'linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.8) 100%)',
-          backdropFilter: 'blur(16px)',
-          borderRadius: 16,
+          backgroundImage: 'none', // MUI's default elevation tint
+          border: `1px solid ${palette.rule}`,
         },
       },
     },
-    
+
     MuiAppBar: {
       styleOverrides: {
         root: {
-          background: 'linear-gradient(180deg, rgba(10, 15, 26, 0.95) 0%, rgba(15, 23, 42, 0.9) 100%)',
-          backdropFilter: 'blur(20px)',
-          borderBottom: '1px solid rgba(99, 102, 241, 0.1)',
-          boxShadow: '0 4px 24px rgba(0, 0, 0, 0.3)',
+          backgroundColor: palette.inkSunken,
+          borderBottom: `1px solid ${palette.rule}`,
+          boxShadow: 'none',
+          backgroundImage: 'none',
         },
       },
     },
-    
+
     MuiDrawer: {
       styleOverrides: {
         paper: {
-          background: 'linear-gradient(180deg, rgba(10, 15, 26, 0.98) 0%, rgba(15, 23, 42, 0.95) 100%)',
-          backdropFilter: 'blur(20px)',
-          borderRight: '1px solid rgba(99, 102, 241, 0.1)',
+          backgroundColor: palette.inkSunken,
+          borderRight: `1px solid ${palette.rule}`,
+          backgroundImage: 'none',
         },
       },
     },
-    
-    MuiTextField: {
+
+    MuiButton: {
+      defaultProps: { disableElevation: true },
       styleOverrides: {
-        root: {
-          '& .MuiOutlinedInput-root': {
-            borderRadius: 12,
-            background: 'rgba(15, 23, 42, 0.6)',
-            '& fieldset': {
-              borderColor: 'rgba(99, 102, 241, 0.2)',
-              borderWidth: 2,
-            },
-            '&:hover fieldset': {
-              borderColor: 'rgba(99, 102, 241, 0.4)',
-            },
-            '&.Mui-focused fieldset': {
-              borderColor: '#6366f1',
-              boxShadow: '0 0 20px rgba(99, 102, 241, 0.2)',
-            },
-          },
+        root: { borderRadius: 5, paddingInline: 14 },
+        containedPrimary: {
+          color: palette.ink,
+          '&:hover': { backgroundColor: palette.ochre, filter: 'brightness(1.08)' },
         },
+        outlined: { borderColor: palette.rule },
       },
     },
-    
+
     MuiChip: {
       styleOverrides: {
-        root: {
-          borderRadius: 8,
-          fontWeight: 500,
-          background: 'rgba(99, 102, 241, 0.15)',
-          border: '1px solid rgba(99, 102, 241, 0.3)',
-        },
-        filled: {
-          background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.3) 0%, rgba(139, 92, 246, 0.3) 100%)',
-        },
+        root: { borderRadius: 4, fontWeight: 500 },
+        // Page numbers, scores and IDs all ride in chips, and all of them are
+        // things the document said.
+        labelSmall: { fontFamily: MONO, fontSize: '0.6875rem' },
+        outlined: { borderColor: palette.rule },
       },
     },
-    
-    MuiLinearProgress: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          height: 8,
-          background: 'rgba(99, 102, 241, 0.15)',
-        },
-        bar: {
-          borderRadius: 8,
-          background: 'linear-gradient(90deg, #6366f1 0%, #06b6d4 100%)',
-        },
-      },
-    },
-    
+
     MuiListItemButton: {
       styleOverrides: {
         root: {
-          borderRadius: 12,
-          margin: '4px 8px',
-          transition: 'all 0.3s ease',
-          '&:hover': {
-            background: 'rgba(99, 102, 241, 0.1)',
-          },
+          borderRadius: 5,
+          marginInline: 8,
           '&.Mui-selected': {
-            background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.2) 0%, rgba(139, 92, 246, 0.15) 100%)',
-            borderLeft: '3px solid #6366f1',
-            '&:hover': {
-              background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.25) 0%, rgba(139, 92, 246, 0.2) 100%)',
-            },
+            backgroundColor: alpha(palette.ochre, 0.14),
+            '&:hover': { backgroundColor: alpha(palette.ochre, 0.2) },
           },
         },
       },
     },
-    
+
     MuiTooltip: {
       styleOverrides: {
         tooltip: {
-          background: 'rgba(15, 23, 42, 0.95)',
-          backdropFilter: 'blur(10px)',
-          border: '1px solid rgba(99, 102, 241, 0.2)',
-          borderRadius: 8,
-          padding: '8px 14px',
-          fontSize: '0.8125rem',
+          backgroundColor: palette.inkSunken,
+          border: `1px solid ${palette.rule}`,
+          fontSize: '0.75rem',
+          lineHeight: 1.5,
+          maxWidth: 320,
+          padding: '8px 10px',
         },
       },
     },
-    
-    MuiFab: {
+
+    MuiAlert: {
       styleOverrides: {
-        root: {
-          background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
-          boxShadow: '0 8px 24px rgba(99, 102, 241, 0.4)',
-          '&:hover': {
-            background: 'linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%)',
-            boxShadow: '0 12px 32px rgba(99, 102, 241, 0.5), 0 0 40px rgba(99, 102, 241, 0.3)',
-          },
-        },
+        root: { border: `1px solid ${palette.rule}`, borderRadius: 5 },
+        standardWarning: { backgroundColor: alpha(palette.oxide, 0.12) },
+        standardSuccess: { backgroundColor: alpha(palette.moss, 0.12) },
+        standardInfo: { backgroundColor: alpha(palette.slate, 0.12) },
       },
     },
+
+    MuiOutlinedInput: {
+      styleOverrides: {
+        notchedOutline: { borderColor: palette.rule },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: { height: 3, borderRadius: 2, backgroundColor: palette.rule },
+      },
+    },
+
+    MuiDivider: { styleOverrides: { root: { borderColor: palette.rule } } },
   },
 });
 
+export { palette };
 export default theme;


### PR DESCRIPTION
Two asks: make the answers more accurate, and make the frontend modern.

---

## Accuracy: measure first

Retrieval changes are easy to argue about and impossible to settle without numbers, so `scripts/eval_retrieval.py` came **before** any change to ranking. It asks 13 questions whose correct source document is known, against the whole 22-document sample corpus.

The questions deliberately avoid the documents' own wording — *"how much do we owe Quantum Industrial Systems"* has to reach **"TOTAL DUE"**, *"vacation days for new starters"* has to reach **"New Employees (Year 1)"**. Matching a shared noun is not evidence that retrieval works.

**Two bugs in the harness had to be fixed before its output meant anything:** it indexed only the five documents the questions pointed at (making "is it in the top five" true by construction), and it read `embeddings_are_real` *after* cleanup, reporting keyword-only matching for a run that used a real model.

| Ranking | recall@1 | recall@3 | MRR |
|---|---|---|---|
| Semantic only | 62% | 77% | 0.699 |
| + keyword (hybrid) | 69% | 92% | 0.827 |
| **+ cross-encoder** | **77%** | **100%** | **0.859** |
| Both | 77% | 100% | 0.859 |

### Cross-encoder reranking

A bi-encoder compares a query vector against passage vectors computed before any question existed, so a passage cannot emphasise the part a given question is about. A cross-encoder reads both together — too slow for a corpus, exactly right for a shortlist.

`ms-marco-MiniLM-L-6-v2` (~80MB) ships with sentence-transformers, so this is a download rather than a new dependency. Unavailable for any reason leaves retrieval on its existing ranking and says why, like every other optional capability here.

**The last two rows are identical, and that is worth reading carefully.** The cross-encoder runs last and reorders everything, so hybrid adds nothing on top of it. Hybrid keeps its place as the *fallback*: without sentence-transformers there is no cross-encoder, and hybrid is then the difference between 69% and 62%. Documented as that rather than claimed as a stack.

Scores stay untouched throughout. Cross-encoder outputs are unbounded logits, not similarities; writing them into `score` would quietly break `RETRIEVAL_MIN_SCORE` and the "% match" beside a citation. There's a test pinning it.

---

## The interface

The theme was indigo-and-purple glassmorphism on Tailwind slate — competent, and indistinguishable from every other AI product. Worse, it spent colour on decoration, leaving nothing to say *"this passage is verified"* with.

This is an instrument for checking claims, used where being wrong is expensive. So it now borrows from archives and annotated legal paper: warm ink and vellum, hairline rules instead of glass and shadow. Two rules hold it together:

> **Ochre means provenance.** The accent is reserved for grounding and citations. If something is ochre, it is a claim you can check.
>
> **Evidence is monospaced.** Verbatim material from a document — quoted passages, page numbers, checksums, IDs — is always mono; the interface's own words are always sans. You can tell them apart without reading.

**No webfonts.** The product runs offline by design, and a font CDN fails exactly when someone is working on a plane. Character comes from scale, weight, tracking, and the sans/mono contrast.

### Also in the shell

- **Chat had no navigation entry at all.** The central feature was reachable only by typing the URL.
- The drawer was permanent at every width, so on a phone it took a third of the screen and could not be dismissed. Now temporary below `md`, with a menu button.
- Active nav state, skip link, visible focus rings, `prefers-reduced-motion` respected, and a sign-out that was previously nowhere in the UI.
- "1 pages" is now "1 page".

---

## Verification

```
ruff check / ruff format / mypy   clean
pytest (bare, as CI runs it)      242 passed, 1 skipped — 72.8% (gate 70%)
npm type-check / lint / build     clean, 0 errors
```

Checked in a browser against a live backend at desktop and at 390px: the mono treatment reads correctly on extracted entities, the drawer collapses to a menu, and content reflows without horizontal scroll.

## Tests added

`test_reranking.py` — a disabled reranker does nothing and says so; an unloadable model degrades instead of raising; every candidate survives reordering; the passage that answers the question ranks first; and scores are never rewritten.

## Not included

Collections/tags still needs Alembic first — the schema is built with `create_all`, so a new column reaches a fresh database and never an existing one.